### PR TITLE
fix: menu misplaced when vditor is not first child

### DIFF
--- a/src/assets/scss/_content.scss
+++ b/src/assets/scss/_content.scss
@@ -11,6 +11,7 @@
 
 .vditor {
   display: flex;
+  position: relative;
   flex-direction: column;
   border: 1px solid var(--border-color);
   border-radius: 3px;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/21083014/77155954-55e8f780-6ad9-11ea-8b4f-cd8f74f9bccd.png)
