### PR TITLE
修复父元素自定义行高时工具栏垂直不居中

### DIFF
--- a/src/assets/scss/_toolbar.scss
+++ b/src/assets/scss/_toolbar.scss
@@ -3,6 +3,7 @@
     background-color: var(--toolbar-background-color);
     border-bottom: 1px solid var(--border-color);
     padding: 0 5px;
+    line-height: 1;
 
     &--hide {
       transition: $transition;


### PR DESCRIPTION
和 normalize.css 一起使用时的:
![image](https://user-images.githubusercontent.com/21083014/77624619-0db85200-6f7d-11ea-8752-8b975a9de0d5.png)
