### PR TITLE
🐛 被 toolbar 覆盖时自动隐藏 popover

### DIFF
--- a/src/assets/scss/_panel.scss
+++ b/src/assets/scss/_panel.scss
@@ -34,6 +34,9 @@
     animation-timing-function: cubic-bezier(.2, 0, .13, 1.5);
     color: var(--toolbar-icon-color);
 
+    --anchor-offset: 0px;
+    --sticky-offset: 0px;
+
     &--none {
       padding: 0;
       animation: none;

--- a/src/assets/scss/_toolbar.scss
+++ b/src/assets/scss/_toolbar.scss
@@ -4,6 +4,7 @@
     border-bottom: 1px solid var(--border-color);
     padding: 0 5px;
     line-height: 1;
+    z-index: 1;
 
     &--hide {
       transition: $transition;

--- a/src/assets/scss/_toolbar.scss
+++ b/src/assets/scss/_toolbar.scss
@@ -5,7 +5,7 @@
     padding: 0 5px;
     line-height: 1;
     position: sticky;
-    top: 1px;
+    top: 0px;
     z-index: 1;
 
     &--hide {

--- a/src/ts/toolbar/EditMode.ts
+++ b/src/ts/toolbar/EditMode.ts
@@ -77,7 +77,7 @@ export const setEditMode = (vditor: IVditor, type: string, event: Event | string
             // 初始化不 focus
             vditor.wysiwyg.element.focus();
         }
-        vditor.wysiwyg.popover.style.display = "none";
+        vditor.wysiwyg.popoverState = false;
     } else if (type === "sv") {
         showToolbar(vditor.toolbar.elements, ["format", "both", "preview"]);
         vditor.undo.resetIcon(vditor);

--- a/src/ts/ui/initUI.ts
+++ b/src/ts/ui/initUI.ts
@@ -85,6 +85,13 @@ const afterRender = (vditor: IVditor, contentElement: HTMLElement) => {
         setPadding(vditor);
     });
 
+    // 监听因为 sticky 导致的 toolbar 与 content 相对位置变化
+    window.addEventListener("scroll", () => {
+        // tslint:disable-next-line: max-line-length
+        const stickyOffset = vditor.wysiwyg.element.parentElement.parentElement.offsetTop - vditor.toolbar.element.offsetTop - vditor.toolbar.element.offsetHeight;
+        vditor.wysiwyg.popover.style.setProperty("--sticky-offset", stickyOffset + "px");
+    });
+
     // set default value
     let initValue = localStorage.getItem(vditor.options.cache.id);
     if (!vditor.options.cache.enable || !initValue) {

--- a/src/ts/wysiwyg/highlightToolbar.ts
+++ b/src/ts/wysiwyg/highlightToolbar.ts
@@ -597,7 +597,7 @@ const setPopoverPosition = (vditor: IVditor, element: HTMLElement) => {
     vditor.wysiwyg.popover.style.top = Math.max(-11, targetElement.offsetTop - 21 - vditor.wysiwyg.element.scrollTop) + "px";
     vditor.wysiwyg.popover.style.left =
         Math.min(targetElement.offsetLeft, vditor.wysiwyg.element.clientWidth - vditor.wysiwyg.popover.clientWidth) + "px";
-    vditor.wysiwyg.popover.setAttribute("data-top", (targetElement.offsetTop - 21).toString());
+    vditor.wysiwyg.popover.style.setProperty("--anchor-offset", (targetElement.offsetTop - 21) + "px");
 };
 
 const genInsertBefore = (range: Range, element: HTMLElement, vditor: IVditor) => {

--- a/src/ts/wysiwyg/highlightToolbar.ts
+++ b/src/ts/wysiwyg/highlightToolbar.ts
@@ -569,7 +569,7 @@ export const highlightToolbar = (vditor: IVditor) => {
 
         if (!blockquoteElement && !topListElement && !tableElement && !blockRenderElement && !aElement
             && !linkRefElement && !footnotesRefElement && !headingElement && !tocElement) {
-            vditor.wysiwyg.popover.style.display = "none";
+            vditor.wysiwyg.popoverState = false;
         }
 
         // 反斜杠特殊处理
@@ -590,13 +590,14 @@ const setPopoverPosition = (vditor: IVditor, element: HTMLElement) => {
     if (tableElement) {
         targetElement = tableElement;
     }
+
+    vditor.wysiwyg.popoverState = true;
+
     vditor.wysiwyg.popover.style.left = "0";
-    vditor.wysiwyg.popover.style.display = "block";
     vditor.wysiwyg.popover.style.top = Math.max(-11, targetElement.offsetTop - 21 - vditor.wysiwyg.element.scrollTop) + "px";
     vditor.wysiwyg.popover.style.left =
         Math.min(targetElement.offsetLeft, vditor.wysiwyg.element.clientWidth - vditor.wysiwyg.popover.clientWidth) + "px";
     vditor.wysiwyg.popover.setAttribute("data-top", (targetElement.offsetTop - 21).toString());
-
 };
 
 const genInsertBefore = (range: Range, element: HTMLElement, vditor: IVditor) => {

--- a/src/ts/wysiwyg/index.ts
+++ b/src/ts/wysiwyg/index.ts
@@ -74,12 +74,13 @@ class WYSIWYG {
 
     // 更新 popover 显示状态与相对位置
     private updatePopoverDisplay() {
-        if (this.popover === undefined || this.popover.getAttribute("data-top") === null) {
+        if (this.popover === undefined) {
             return;
         }
-        const top = parseInt(this.popover.getAttribute("data-top"), 10) - this.element.scrollTop;
+        const top = parseInt(this.popover.style.getPropertyValue("--anchor-offset"), 10) - this.element.scrollTop;
         const computedTop = Math.max(-11, Math.min(top, this.element.clientHeight - 21));
-        if (this.element.scrollTop !== 0 && computedTop < 0) {
+        const stickyOffset = parseInt(this.popover.style.getPropertyValue("--sticky-offset"), 10);
+        if (this.element.scrollTop !== 0 && computedTop + stickyOffset < 0) {
             this.popoverShouldDisplay = false;
         } else {
             this.popover.style.top = computedTop + "px";

--- a/src/ts/wysiwyg/index.ts
+++ b/src/ts/wysiwyg/index.ts
@@ -27,6 +27,7 @@ class WYSIWYG {
     private iPopoverState: boolean = false;
     private iPopoverShouldDisplay: boolean = true;
 
+    // popover 开启状态
     public set popoverState(state: boolean) {
         this.iPopoverState = state;
         if (state) {
@@ -36,6 +37,7 @@ class WYSIWYG {
         }
     }
 
+    // popover 显示状态
     private set popoverShouldDisplay(state: boolean) {
         this.iPopoverShouldDisplay = state;
         if (this.iPopoverShouldDisplay && this.iPopoverState) {
@@ -66,13 +68,13 @@ class WYSIWYG {
         selectEvent(vditor, this.element);
     }
 
+    // 更新 popover 显示状态与相对位置
     private updatePopoverDisplay() {
-        if (this.popover === undefined || parseInt(this.popover.getAttribute("data-top"), 10) === null) {
+        if (this.popover === undefined || this.popover.getAttribute("data-top") === null) {
             return;
         }
         const top = parseInt(this.popover.getAttribute("data-top"), 10) - this.element.scrollTop;
         const computedTop = Math.max(-11, Math.min(top, this.element.clientHeight - 21));
-        // tslint:disable-next-line: max-line-length
         if (this.element.scrollTop !== 0 && computedTop < 0) {
             this.popoverShouldDisplay = false;
         } else {
@@ -96,8 +98,8 @@ class WYSIWYG {
                 });
         }
 
+        // 滚动时更新 popover 位置
         window.addEventListener("scroll", this.updatePopoverDisplay);
-
         this.element.addEventListener("scroll", () => {
             vditor.hint.element.style.display = "none";
             this.updatePopoverDisplay();

--- a/src/ts/wysiwyg/index.ts
+++ b/src/ts/wysiwyg/index.ts
@@ -43,6 +43,10 @@ class WYSIWYG {
         if (this.iPopoverShouldDisplay && this.iPopoverState) {
             this.popover.style.display = "block";
         } else {
+            const inputs = this.popover.getElementsByTagName("input");
+            for (let i = 0; i < inputs.length; i++) {
+                inputs[i].blur();
+            }
             this.popover.style.display = "none";
         }
     }

--- a/src/ts/wysiwyg/processKeydown.ts
+++ b/src/ts/wysiwyg/processKeydown.ts
@@ -70,7 +70,7 @@ export const processKeydown = (vditor: IVditor, event: KeyboardEvent) => {
     if (codeRenderElement) {
         // esc: 退出编辑，仅展示渲染
         if (event.key === "Escape" && codeRenderElement.children.length === 2) {
-            vditor.wysiwyg.popover.style.display = "none";
+            vditor.wysiwyg.popoverState = false;
             (codeRenderElement.firstElementChild as HTMLElement).style.display = "none";
             vditor.wysiwyg.element.blur();
             event.preventDefault();

--- a/src/ts/wysiwyg/setHeading.ts
+++ b/src/ts/wysiwyg/setHeading.ts
@@ -39,5 +39,5 @@ export const removeHeading = (vditor: IVditor) => {
         blockElement.outerHTML = `<p data-block="0">${blockElement.innerHTML}</p>`;
         setRangeByWbr(vditor.wysiwyg.element, range);
     }
-    vditor.wysiwyg.popover.style.display = "none";
+    vditor.wysiwyg.popoverState = false;
 };

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -448,6 +448,7 @@ interface IVditor {
         hlToolbarTimeoutId: number,
         preventInput: boolean,
         composingLock: boolean,
+        popoverState: boolean,
     };
     ir?: {
         element: HTMLPreElement,


### PR DESCRIPTION
由于新的 `sticky` toolbar 特性，当 popover 与其有交集时会覆盖在其上，一定程度上降低了用户体验。

此 PR 实现了当 toolbar 与 popover 有重叠时，popover 将自动隐藏；一旦失去重叠，popover 将自动重新显示。特别地，当位于编辑区域顶端时，popover 不会被隐藏。

API 变动：当其他组件想要关闭/开启 popover 时，不应直接设置 `vditor.wysiwyg.popover.style.display`，而应当修改 `vditor.wysiwyg.popoverState` 属性。