### PR TITLE
🎨 改进 Counter

### DIFF
--- a/src/ts/counter/index.ts
+++ b/src/ts/counter/index.ts
@@ -5,11 +5,12 @@ export class Counter {
         this.element = document.createElement("div");
         this.element.className = "vditor-counter";
 
-        this.render(0, vditor.options.counter);
+        this.render("", vditor.options.counter);
 
     }
 
-    public render(length: number, counter: number) {
+    public render(text: string, counter: number) {
+        const length = text.endsWith("\n") ? text.length - 1 : text.length;
         if (length > counter) {
             this.element.className = "vditor-counter vditor-counter--error";
         } else {

--- a/src/ts/counter/index.ts
+++ b/src/ts/counter/index.ts
@@ -9,13 +9,13 @@ export class Counter {
 
     }
 
-    public render(text: string, counter: number) {
+    public render(text: string, counter: number, label: string = "Markdown") {
         const length = text.endsWith("\n") ? text.length - 1 : text.length;
         if (length > counter) {
             this.element.className = "vditor-counter vditor-counter--error";
         } else {
             this.element.className = "vditor-counter";
         }
-        this.element.innerHTML = `${length}/${counter}`;
+        this.element.innerHTML = `${label}: ${length}/${counter}`;
     }
 }

--- a/src/ts/ir/process.ts
+++ b/src/ts/ir/process.ts
@@ -54,7 +54,7 @@ export const processAfterRender = (vditor: IVditor, options = {
         }
 
         if (vditor.options.counter > 0) {
-            vditor.counter.render(text.length, vditor.options.counter);
+            vditor.counter.render(text, vditor.options.counter);
         }
 
         if (vditor.options.cache.enable) {

--- a/src/ts/sv/inputEvent.ts
+++ b/src/ts/sv/inputEvent.ts
@@ -5,7 +5,7 @@ export const inputEvent = (vditor: IVditor, options = {
     enableInput: true,
 }) => {
     if (vditor.options.counter > 0) {
-        vditor.counter.render(getMarkdown(vditor).length, vditor.options.counter);
+        vditor.counter.render(getMarkdown(vditor), vditor.options.counter);
     }
     if (typeof vditor.options.input === "function" && options.enableInput) {
         vditor.options.input(getMarkdown(vditor),

--- a/src/ts/wysiwyg/afterRenderEvent.ts
+++ b/src/ts/wysiwyg/afterRenderEvent.ts
@@ -21,7 +21,7 @@ export const afterRenderEvent = (vditor: IVditor, options = {
         }
 
         if (vditor.options.counter > 0) {
-            vditor.counter.render(text.length, vditor.options.counter);
+            vditor.counter.render(text, vditor.options.counter);
         }
 
         if (vditor.options.cache.enable) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -396,7 +396,7 @@ interface IVditor {
     };
     counter?: {
         element: HTMLElement
-        render(length: number, counter: number): void,
+        render(text: string, counter: number): void,
     };
     resize?: {
         element: HTMLElement,

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -396,7 +396,7 @@ interface IVditor {
     };
     counter?: {
         element: HTMLElement
-        render(text: string, counter: number): void,
+        render(text: string, counter: number, label?: string): void,
     };
     resize?: {
         element: HTMLElement,


### PR DESCRIPTION
9bdc88f：改进字数统计，去除末尾换行符（解决空内容长度显示为 1 的问题）。

API 变动：`counter.render` 的首个参数从接收长度改为直接接收字符串。

----

3356608：添加 label，使字数统计意义更明确，不易引起混淆；同时为添加其他意义（例如纯字符、HTML）的长度统计打基础。

API 变动：`counter.render` 可选的第三个参数接收 `counter` 的 label，默认值为 `"Markdown"`。