### PR TITLE
🐛 全屏模式文末空白

### DIFF
--- a/src/assets/scss/_content.scss
+++ b/src/assets/scss/_content.scss
@@ -72,8 +72,9 @@
     }
 
     &:after {
+      $height: var(--editor-bottom);
       content: "";
-      height: var(--editor-bottom);
+      height: var(--editor-bottom-actual, $height);
       display: block;
     }
   }
@@ -211,14 +212,14 @@
 
     &__close {
       position: absolute;
-      color:  var(--toolbar-icon-color);
+      color: var(--toolbar-icon-color);
       top: -7px;
       right: -15px;
       font-weight: bold;
       cursor: pointer;
 
       &:hover {
-        color:  var(--toolbar-icon-hover-color);
+        color: var(--toolbar-icon-hover-color);
       }
     }
   }

--- a/src/assets/scss/_ir.scss
+++ b/src/assets/scss/_ir.scss
@@ -137,8 +137,9 @@
     }
 
     &:after {
+      $height: var(--editor-bottom);
       content: "";
-      height: var(--editor-bottom);
+      height: var(--editor-bottom-actual, $height);
       display: block;
     }
 

--- a/src/assets/scss/_wysiwyg.scss
+++ b/src/assets/scss/_wysiwyg.scss
@@ -27,8 +27,9 @@
     }
 
     &:after {
+      $height: var(--editor-bottom);
       content: "";
-      height: var(--editor-bottom);
+      height: var(--editor-bottom-actual, $height);
       display: block;
     }
   }

--- a/src/ts/toolbar/Fullscreen.ts
+++ b/src/ts/toolbar/Fullscreen.ts
@@ -14,8 +14,9 @@ export class Fullscreen extends MenuItem {
     public _bindEvent(vditor: IVditor, menuItem: IMenuItem) {
         this.element.children[0].addEventListener(getEventName(), function(event) {
             event.preventDefault();
-            if (vditor.element.className.indexOf("vditor--fullscreen") > -1) {
+            if (vditor.element.className.includes("vditor--fullscreen")) {
                 this.innerHTML = menuItem.icon || fullscreenSVG;
+                vditor.element.style.removeProperty("--editor-bottom-actual");
                 vditor.element.classList.remove("vditor--fullscreen");
                 Object.keys(vditor.toolbar.elements).forEach((key) => {
                     const svgElement = vditor.toolbar.elements[key].firstChild as HTMLElement;
@@ -25,6 +26,7 @@ export class Fullscreen extends MenuItem {
                 });
             } else {
                 this.innerHTML = menuItem.icon || contractSVG;
+                vditor.element.style.setProperty("--editor-bottom-actual", "0");
                 vditor.element.classList.add("vditor--fullscreen");
                 Object.keys(vditor.toolbar.elements).forEach((key) => {
                     const svgElement = vditor.toolbar.elements[key].firstChild as HTMLElement;


### PR DESCRIPTION
修复全屏模式下文末无故空白（由 `:after` 引起）。