### PR TITLE
style: 优化分隔符样式

### DIFF
--- a/src/assets/scss/_toolbar.scss
+++ b/src/assets/scss/_toolbar.scss
@@ -32,7 +32,7 @@
         border: 0;
         padding: 10px 5px;
         background-color: transparent;
-        height: 35px;
+        height: var(--toolbar-height);
         width: 25px;
         box-sizing: border-box;
         font-size: 0;
@@ -59,7 +59,7 @@
       input {
         position: absolute;
         width: 25px;
-        height: 35px;
+        height: var(--toolbar-height);
         top: 0;
         left: 0;
         cursor: pointer;
@@ -70,8 +70,9 @@
 
     &__divider {
       float: left;
-      width: 16px;
-      height: 35px;
+      height: calc(var(--toolbar-height) - (var(--toolbar-divider-margin-top) * 2));
+      border-left: 1px solid var(--border-color);
+      margin: var(--toolbar-divider-margin-top) 8px;
     }
 
     &__br {

--- a/src/assets/scss/index.scss
+++ b/src/assets/scss/index.scss
@@ -18,6 +18,8 @@ $max-width: 520px !default;
   --toolbar-background-color: #f6f8fa;
   --toolbar-icon-color: #586069;
   --toolbar-icon-hover-color: #{$blurColor};
+  --toolbar-height: 35px;
+  --toolbar-divider-margin-top: 8px;
 
   --textarea-background-color: #fafbfc;
   --textarea-text-color: #24292e;


### PR DESCRIPTION
light:
![image](https://user-images.githubusercontent.com/2987467/87239156-6df4d600-c43e-11ea-8a8d-f3b10177c756.png)
dark:
![image](https://user-images.githubusercontent.com/2987467/87239159-7220f380-c43e-11ea-8241-43deb3d4bc04.png)

当 `--toolbar-divider-margin-top: 0px` 时会变成：

![image](https://user-images.githubusercontent.com/2987467/87239186-bc09d980-c43e-11ea-9dd3-78989078f127.png)


* PR 请提交到开发分支上
* 我们对编码风格有着较为严格的要求，请在阅读代码后模仿类似风格提交
