### PR TITLE
fix: safari下选中文字添加标题文字会消失

### DIFF
--- a/src/ts/ir/process.ts
+++ b/src/ts/ir/process.ts
@@ -80,12 +80,14 @@ export const processHeading = (vditor: IVditor, value: string) => {
     if (headingElement) {
         if (value === "") {
             const headingMarkerElement = headingElement.querySelector(".vditor-ir__marker--heading");
-            range.selectNodeContents(headingMarkerElement);
+            const selection = window.getSelection();
+            selection.selectAllChildren(headingMarkerElement)
             document.execCommand("delete");
         } else {
-            range.selectNodeContents(headingElement);
-            range.collapse(true);
-            document.execCommand("insertHTML", false, value);
+            const html = value + headingElement.innerText;
+            const selection = window.getSelection();
+            selection.selectAllChildren(headingElement)
+            document.execCommand("insertHTML", false, html);
         }
         highlightToolbarIR(vditor);
         renderToc(vditor);


### PR DESCRIPTION
safari即时渲染模式下 选中的文字会消失
![QQ20200723-175018-HD](https://user-images.githubusercontent.com/34639100/88273759-3d018480-cd0d-11ea-9b90-99d36a344158.gif)
