### PR TITLE
style: 去除ios safari默认改变字体功能

### DIFF
--- a/src/assets/scss/_ir.scss
+++ b/src/assets/scss/_ir.scss
@@ -128,6 +128,7 @@
   }
 
   pre.vditor-reset {
+    -webkit-user-modify: read-write-plaintext-only;
     background-color: var(--panel-background-color);
     margin: 0;
     white-space: pre-wrap;

--- a/src/assets/scss/_sv.scss
+++ b/src/assets/scss/_sv.scss
@@ -1,5 +1,5 @@
 .vditor-sv {
-
+  -webkit-user-modify: read-write-plaintext-only;
   font-family: $font-family-base;
   margin: 0 1px 0 0;
   overflow: auto;

--- a/src/assets/scss/_wysiwyg.scss
+++ b/src/assets/scss/_wysiwyg.scss
@@ -6,6 +6,7 @@
   min-width: 1px;
 
   pre.vditor-reset {
+    -webkit-user-modify: read-write-plaintext-only;
     background-color: var(--panel-background-color);
     margin: 0;
     white-space: pre-wrap;


### PR DESCRIPTION
ir模式和sv模式下safari自带的字体功能不生效， wysiwyg模式中下划线有问题

![4831A7CC9356248C8DC59935433B8C8A](https://user-images.githubusercontent.com/34639100/90233419-b98d0c00-de50-11ea-9e2f-396d11276611.png)
![8815D764C1D68F28C0A628DA29A193F7](https://user-images.githubusercontent.com/34639100/90233445-c14cb080-de50-11ea-99ba-913ad4c31ae0.png)
