### PR TITLE
增加onInput事件和beforeDefaultToolbar

### DIFF
--- a/src/ts/ir/index.ts
+++ b/src/ts/ir/index.ts
@@ -6,6 +6,7 @@ import {
     dropEvent,
     focusEvent,
     hotkeyEvent,
+    onInputEvent,
     scrollCenter,
     selectEvent,
 } from "../util/editorCommonEvent";
@@ -39,6 +40,7 @@ class IR {
 
         this.bindEvent(vditor);
 
+        onInputEvent(vditor, this.element);
         focusEvent(vditor, this.element);
         blurEvent(vditor, this.element);
         hotkeyEvent(vditor, this.element);

--- a/src/ts/sv/index.ts
+++ b/src/ts/sv/index.ts
@@ -5,6 +5,7 @@ import {
     dropEvent,
     focusEvent,
     hotkeyEvent,
+    onInputEvent,
     scrollCenter,
     selectEvent,
 } from "../util/editorCommonEvent";
@@ -28,6 +29,7 @@ class Editor {
 
         this.bindEvent(vditor);
 
+        onInputEvent(vditor, this.element);
         focusEvent(vditor, this.element);
         blurEvent(vditor, this.element);
         hotkeyEvent(vditor, this.element);

--- a/src/ts/util/Options.ts
+++ b/src/ts/util/Options.ts
@@ -130,6 +130,9 @@ export class Options {
             } else {
                 this.options.toolbar = this.mergeToolbar(this.defaultOptions.toolbar);
             }
+            if (this.options.beforeDefaultToolbar) {
+                this.options.toolbar = this.mergeToolbar(this.options.beforeDefaultToolbar).concat(this.options.toolbar as IMenuItem[]);
+            }
             if (this.options.preview?.theme?.list) {
                 this.defaultOptions.preview.theme.list = this.options.preview.theme.list;
             }

--- a/src/ts/util/editorCommonEvent.ts
+++ b/src/ts/util/editorCommonEvent.ts
@@ -24,6 +24,14 @@ export const focusEvent = (vditor: IVditor, editorElement: HTMLElement) => {
     });
 };
 
+export const onInputEvent = (vditor: IVditor, editorElement: HTMLElement) => {
+    editorElement.addEventListener("input", () => {
+        if (vditor.options.onInput) {
+            vditor.options.onInput();
+        }
+    });
+};
+
 export const blurEvent = (vditor: IVditor, editorElement: HTMLElement) => {
     editorElement.addEventListener("blur", (event) => {
         if (vditor.currentMode === "ir") {

--- a/src/ts/wysiwyg/index.ts
+++ b/src/ts/wysiwyg/index.ts
@@ -5,7 +5,7 @@ import {isCtrl, isFirefox} from "../util/compatibility";
 import {
     blurEvent,
     copyEvent, cutEvent,
-    dropEvent,
+    dropEvent,onInputEvent,
     focusEvent,
     hotkeyEvent,
     scrollCenter,
@@ -59,6 +59,7 @@ class WYSIWYG {
 
         this.bindEvent(vditor);
 
+        onInputEvent(vditor, this.element);
         focusEvent(vditor, this.element);
         blurEvent(vditor, this.element);
         hotkeyEvent(vditor, this.element);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -484,6 +484,7 @@ interface IOptions {
     lang?: (keyof II18n);
     /** @link https://ld246.com/article/1549638745630#options-toolbar */
     toolbar?: Array<string | IMenuItem>;
+    beforeDefaultToolbar?: Array<string | IMenuItem>;
     /** @link https://ld246.com/article/1549638745630#options-resize */
     resize?: IResize;
     /** @link https://ld246.com/article/1549638745630#options-counter */
@@ -540,6 +541,8 @@ interface IOptions {
 
     /** 聚焦后触发  */
     focus?(value: string): void;
+
+    onInput?(): void;
 
     /** 失焦后触发 */
     blur?(value: string): void;


### PR DESCRIPTION
增加了两个选项
- onInput: 当在markdown输入时回调, 无参数, 现在的input事件只有ctrl+s才会触发, 所以创建了这个, 没有参数是发现如果在每次nput获取整个markdown文本, 会很卡..
- beforeDefaultToolbar: 可以在默认的toolbar之前增加其他toolbar.