### PR TITLE
feat: hint支持异步

### DIFF
--- a/src/ts/hint/index.ts
+++ b/src/ts/hint/index.ts
@@ -59,8 +59,8 @@ export class Hint {
                 vditor.options.hint.extend.forEach((item) => {
                     if (item.key === this.splitChar) {
                         clearTimeout(this.timeId);
-                        this.timeId = window.setTimeout(() => {
-                            this.genHTML(item.hint(key), key, vditor);
+                        this.timeId = window.setTimeout(async () => {
+                            this.genHTML(await item.hint(key), key, vditor);
                         }, vditor.options.hint.delay);
                     }
                 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -537,7 +537,7 @@ interface IHintData {
 interface IHintExtend {
     key: string;
 
-    hint?(value: string): IHintData[];
+    hint?(value: string): IHintData[] | Promise<IHintData[]>;
 }
 
 /** @link https://ld246.com/article/1549638745630#options-hint */


### PR DESCRIPTION
<!--

* PR 请提交到 dev 开发分支上

-->

hint扩展支持异步返回，`@`自动补全常用场景是从服务端查询结果
https://github.com/Vanessa219/vditor/issues/1064 提供了同步ajax的解决方法，但这会导致浏览器卡顿。
更好的方案是hint支持Promise，从源代码看，hint扩展使用setTimeout进行调用，改为异步函数，工作量并不大