### PR TITLE
fix: 修复外部文件拖拽在firefox浏览器或自定义handler时无法工作

### DIFF
--- a/src/ts/util/editorCommonEvent.ts
+++ b/src/ts/util/editorCommonEvent.ts
@@ -62,7 +62,7 @@ export const dropEvent = (vditor: IVditor, editorElement: HTMLElement) => {
             if (event.dataTransfer.getData(Constants.DROP_EDITOR)) {
                 // 编辑器内选中文字拖拽
                 execAfterRender(vditor);
-            } else if (event.dataTransfer.types[0] === "Files" || event.dataTransfer.types.includes("text/html")) {
+            } else if (event.dataTransfer.types.includes("Files") || event.dataTransfer.types.includes("text/html")) {
                 // 外部文件拖入编辑器中或者编辑器内选中文字拖拽
                 paste(vditor, event, {
                     pasteCode: (code: string) => {

--- a/src/ts/util/fixBrowserBehavior.ts
+++ b/src/ts/util/fixBrowserBehavior.ts
@@ -1264,7 +1264,7 @@ export const paste = async (vditor: IVditor, event: (ClipboardEvent | DragEvent)
     } else {
         textHTML = event.dataTransfer.getData("text/html");
         textPlain = event.dataTransfer.getData("text/plain");
-        if (event.dataTransfer.types[0] === "Files") {
+        if (event.dataTransfer.types.includes("Files")) {
             files = event.dataTransfer.items;
         }
     }
@@ -1410,7 +1410,7 @@ export const paste = async (vditor: IVditor, event: (ClipboardEvent | DragEvent)
                 processPaste(vditor, vditor.lute.HTML2Md(tempElement.innerHTML).trimRight());
             }
             vditor.outline.render(vditor);
-        } else if (files.length > 0 && vditor.options.upload.url) {
+        } else if (files.length > 0 && (vditor.options.upload.url||vditor.options.upload.handler)) {
             await uploadFiles(vditor, files);
         } else if (textPlain.trim() !== "" && files.length === 0) {
             if (vditor.currentMode === "ir") {


### PR DESCRIPTION
firefox浏览器的文件拖拽事件types属性为["application/x-moz-file","Files"]
在代码中使用types[0]="Files"判断是否为文件拖拽，这导致在firefox上无法识别文件拖拽

因为判断了url为空则不执行传，当使用upload.handler自定义上传处理函数,文件拖拽无法正常工作。

<!--

* PR 请提交到 dev 开发分支上

-->