### PR TITLE
fix: 修复在单页面应用中编辑器无法切换语言

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,7 @@ class Vditor extends VditorMethod {
                     "options.lang error, see https://ld246.com/article/1549638745630#options",
                 );
             } else {
-                addScript(`${mergedOptions.cdn}/dist/js/i18n/${mergedOptions.lang}.js`, "vditorI18nScript").then(() => {
+                addScript(`${mergedOptions.cdn}/dist/js/i18n/${mergedOptions.lang}.js`, "vditorI18nScript"+"_"+mergedOptions.lang).then(() => {
                     this.init(id as HTMLElement, mergedOptions);
                 });
             }


### PR DESCRIPTION
编辑器缓存i18n脚本时未考虑多语言切换
通过给缓存key加上语言的后缀解决

<!--

* PR 请提交到 dev 开发分支上

-->