### PR TITLE
fix: 修复所见即所得模式下,代码语言选择在firefox不工作

### DIFF
--- a/src/ts/hint/index.ts
+++ b/src/ts/hint/index.ts
@@ -148,15 +148,22 @@ ${i === 0 ? "class='vditor-hint--current'" : ""}> ${html}</button>`;
                 return;
             }
         }
-        if (vditor.currentMode === "wysiwyg" && range.startContainer.nodeType !== 3 &&
-            (range.startContainer as HTMLElement).firstElementChild.classList.contains("vditor-input")) {
-            const inputElement = (range.startContainer as HTMLElement).firstElementChild as HTMLInputElement;
-            inputElement.value = value.trimRight();
-            range.selectNodeContents(inputElement);
-            range.collapse(false);
-            inputElement.dispatchEvent(new CustomEvent("input"));
-            this.recentLanguage = value.trimRight();
-            return;
+        if (vditor.currentMode === "wysiwyg" && range.startContainer.nodeType !== 3 ) {
+            const startContainer = range.startContainer as HTMLElement;
+            let inputElement: HTMLInputElement;
+            if(startContainer.classList.contains("vditor-input")) {
+                inputElement = startContainer as HTMLInputElement;
+            } else {
+                inputElement = startContainer.firstElementChild as HTMLInputElement;
+            }
+            if (inputElement && inputElement.classList.contains("vditor-input")) {
+                inputElement.value = value.trimRight();
+                range.selectNodeContents(inputElement);
+                range.collapse(false);
+                inputElement.dispatchEvent(new CustomEvent("input"));
+                this.recentLanguage = value.trimRight();
+                return;
+            }
         }
 
         range.setStart(range.startContainer, this.lastIndex);


### PR DESCRIPTION
在firefox中使用所见即所得模式,编辑```插入代码,选择语言回车无效
控制台报错`i.startContainer.firstElementChild is null`
原因是range.startContainer在firefox和chrome表现不一致
在chrome中startContrainer是input的父元素,在firefox中是input本身

<!--

* PR 请提交到 dev 开发分支上

-->