### PR TITLE
fix: 修复非分屏编辑退出全屏后,工具栏布局错误

### DIFF
--- a/src/ts/ui/initUI.ts
+++ b/src/ts/ui/initUI.ts
@@ -119,6 +119,11 @@ export const setPadding = (vditor: IVditor) => {
             parseInt(vditor[vditor.currentMode].element.style.paddingLeft || "0", 10) +
             (vditor.options.outline.position === "left" ? vditor.outline.element.offsetWidth : 0)) + "px";
     }
+    if (vditor.preview.element.style.display === "block" && vditor.currentMode !== "sv"){
+        const padding = (vditor.preview.element.parentElement.clientWidth
+            - vditor.options.preview.maxWidth) / 2;
+        vditor.toolbar.element.style.paddingLeft = Math.max(minPadding, padding) + "px";
+    }
 };
 
 export const setTypewriterPosition = (vditor: IVditor) => {


### PR DESCRIPTION
当前版本在全屏时使用预览功能,然后再退出全屏,工具栏的内间距没有恢复
![图片](https://user-images.githubusercontent.com/13045857/143395834-496e0122-afbb-4832-ac6d-6675a46bc4c7.png)

<!--

* PR 请提交到 dev 开发分支上

-->