### PR TITLE
fix: 在焦点更改后，代码选择列表不自动隐藏

### DIFF
--- a/src/ts/util/editorCommonEvent.ts
+++ b/src/ts/util/editorCommonEvent.ts
@@ -22,7 +22,7 @@ export const focusEvent = (vditor: IVditor, editorElement: HTMLElement) => {
         if (vditor.options.focus) {
             vditor.options.focus(getMarkdown(vditor));
         }
-        hidePanel(vditor, ["subToolbar"]);
+        hidePanel(vditor, ["subToolbar", "hint"]);
     });
 };
 


### PR DESCRIPTION
在焦点更改后，隐藏代码选择列表
<!--

* PR 请提交到 dev 开发分支上

-->