### PR TITLE
feat: 表情支持自定义顺序

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -85,10 +85,15 @@ const initVditor = (language) => {
     hint: {
       emojiPath: 'https://cdn.jsdelivr.net/npm/vditor@1.8.3/dist/images/emoji',
       emojiTail: '<a href="https://ld246.com/settings/function" target="_blank">设置常用表情</a>',
-      emoji: {
-        'sd': '💔',
+      emoji: [
+        {
         'j': 'https://unpkg.com/vditor@1.3.1/dist/images/emoji/j.png',
-      },
+        'sd': '💔',
+        },
+        {
+          "100": "💯",
+        }
+      ],
       parse: false,
       extend: [
         {

--- a/src/index.ts
+++ b/src/index.ts
@@ -466,7 +466,9 @@ class Vditor extends VditorMethod {
         if (mergedOptions.upload.url || mergedOptions.upload.handler) {
             this.vditor.upload = new Upload();
         }
-
+        let emojis: IObject = this.vditor.options.hint.emoji instanceof Array 
+                    ? Object.assign({}, ...this.vditor.options.hint.emoji) 
+                    : this.vditor.options.hint.emoji
         addScript(
             mergedOptions._lutePath ||
             `${mergedOptions.cdn}/dist/js/lute/lute.min.js`,
@@ -477,7 +479,7 @@ class Vditor extends VditorMethod {
                 codeBlockPreview: this.vditor.options.preview.markdown
                     .codeBlockPreview,
                 emojiSite: this.vditor.options.hint.emojiPath,
-                emojis: this.vditor.options.hint.emoji,
+                emojis: emojis,
                 fixTermTypo: this.vditor.options.preview.markdown.fixTermTypo,
                 footnotes: this.vditor.options.preview.markdown.footnotes,
                 headingAnchor: false,

--- a/src/ts/hint/index.ts
+++ b/src/ts/hint/index.ts
@@ -39,21 +39,24 @@ export class Hint {
             if (this.splitChar === ":") {
                 const emojiHint = key === "" ? vditor.options.hint.emoji : vditor.lute.GetEmojis();
                 const matchEmojiData: IHintData[] = [];
-                Object.keys(emojiHint).forEach((keyName) => {
-                    if (keyName.indexOf(key.toLowerCase()) === 0) {
-                        if (emojiHint[keyName].indexOf(".") > -1) {
-                            matchEmojiData.push({
-                                html: `<img src="${emojiHint[keyName]}" title=":${keyName}:"/> :${keyName}:`,
-                                value: `:${keyName}:`,
-                            });
-                        } else {
-                            matchEmojiData.push({
-                                html: `<span class="vditor-hint__emoji">${emojiHint[keyName]}</span>${keyName}`,
-                                value: emojiHint[keyName],
-                            });
+                const emojiHintGroup = emojiHint instanceof Array ? emojiHint : [emojiHint];
+                emojiHintGroup.forEach(emoji=>{
+                    Object.keys(emoji).forEach((keyName) => {
+                        if (keyName.indexOf(key.toLowerCase()) === 0) {
+                            if (emoji[keyName].indexOf(".") > -1) {
+                                matchEmojiData.push({
+                                    html: `<img src="${emoji[keyName]}" title=":${keyName}:"/> :${keyName}:`,
+                                    value: `:${keyName}:`,
+                                });
+                            } else {
+                                matchEmojiData.push({
+                                    html: `<span class="vditor-hint__emoji">${emoji[keyName]}</span>${keyName}`,
+                                    value: emoji[keyName],
+                                });
+                            }
                         }
-                    }
-                });
+                    });
+                })
                 this.genHTML(matchEmojiData, key, vditor);
             } else {
                 vditor.options.hint.extend.forEach((item) => {

--- a/src/ts/markdown/previewRender.ts
+++ b/src/ts/markdown/previewRender.ts
@@ -19,7 +19,7 @@ import {plantumlRender} from "./plantumlRender";
 import {setLute} from "./setLute";
 import {speechRender} from "./speechRender";
 
-const mergeOptions = (options?: IPreviewOptions) => {
+const mergeOptions = (options?: IPreviewOptions):IPreviewOptions => {
     const defaultOption: IPreviewOptions = {
         anchor: 0,
         cdn: Constants.CDN,
@@ -44,11 +44,14 @@ const mergeOptions = (options?: IPreviewOptions) => {
 export const md2html = (mdText: string, options?: IPreviewOptions) => {
     const mergedOptions = mergeOptions(options);
     return addScript(`${mergedOptions.cdn}/dist/js/lute/lute.min.js`, "vditorLuteScript").then(() => {
+        const emojis: IObject = mergedOptions.customEmoji instanceof Array 
+                        ? Object.assign({}, ...mergedOptions.customEmoji) 
+                        : mergedOptions.customEmoji
         const lute = setLute({
             autoSpace: mergedOptions.markdown.autoSpace,
             codeBlockPreview: mergedOptions.markdown.codeBlockPreview,
             emojiSite: mergedOptions.emojiPath,
-            emojis: mergedOptions.customEmoji,
+            emojis: emojis,
             fixTermTypo: mergedOptions.markdown.fixTermTypo,
             footnotes: mergedOptions.markdown.footnotes,
             headingAnchor: mergedOptions.anchor !== 0,

--- a/src/ts/toolbar/Emoji.ts
+++ b/src/ts/toolbar/Emoji.ts
@@ -13,16 +13,19 @@ export class Emoji extends MenuItem {
         panelElement.className = "vditor-panel vditor-panel--arrow";
 
         let commonEmojiHTML = "";
-        Object.keys(vditor.options.hint.emoji).forEach((key) => {
-            const emojiValue = vditor.options.hint.emoji[key];
-            if (emojiValue.indexOf(".") > -1) {
-                commonEmojiHTML += `<button data-value=":${key}: " data-key=":${key}:"><img
-data-value=":${key}: " data-key=":${key}:" class="vditor-emojis__icon" src="${emojiValue}"/></button>`;
-            } else {
-                commonEmojiHTML += `<button data-value="${emojiValue} "
- data-key="${key}"><span class="vditor-emojis__icon">${emojiValue}</span></button>`;
-            }
-        });
+        const emojiGroup = vditor.options.hint.emoji instanceof Array ? vditor.options.hint.emoji : [vditor.options.hint.emoji]
+        emojiGroup.forEach(emoji=>{
+            Object.keys(emoji).forEach((key) => {
+                const emojiValue = emoji[key];
+                if (emojiValue.indexOf(".") > -1) {
+                    commonEmojiHTML += `<button data-value=":${key}: " data-key=":${key}:"><img
+    data-value=":${key}: " data-key=":${key}:" class="vditor-emojis__icon" src="${emojiValue}"/></button>`;
+                } else {
+                    commonEmojiHTML += `<button data-value="${emojiValue} "
+    data-key="${key}"><span class="vditor-emojis__icon">${emojiValue}</span></button>`;
+                }
+            });
+        })
 
         const tailHTML = `<div class="vditor-emojis__tail">
     <span class="vditor-emojis__tip"></span><span>${vditor.options.hint.emojiTail || ""}</span>

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -507,7 +507,7 @@ interface IPreviewActionCustom {
 
 interface IPreviewOptions {
     mode: "dark" | "light";
-    customEmoji?: IObject;
+    customEmoji?: IObject | Array<IObject>;
     lang?: (keyof II18n);
     i18n?: ITips;
     lazyLoadImage?: string;
@@ -549,7 +549,7 @@ interface IHint {
     /** 提示 debounce 毫秒间隔。默认值: 200 */
     delay?: number;
     /** 默认表情，可从 [lute/emoji_map](https://github.com/88250/lute/blob/master/parse/emoji_map.go#L32) 中选取，也可自定义 */
-    emoji?: IObject;
+    emoji?: IObject | Array<IObject>;
     /** 表情图片地址。默认值: 'https://cdn.jsdelivr.net/npm/vditor@${VDITOR_VERSION}/dist/images/emoji' */
     emojiPath?: string;
     extend?: IHintExtend[];


### PR DESCRIPTION
使用对象做为表情数据集,无法定制显示的顺序
由于对象是无序的,支持传递对象数组

```javascript
[
        {
        'j': 'https://unpkg.com/vditor@1.3.1/dist/images/emoji/j.png',
        'sd': '💔',
        },
        {
          "100": "💯",
        }
]
```

![图片](https://user-images.githubusercontent.com/13045857/143516227-41be3f35-8354-41b7-ba82-020f13198646.png)

<!--

* PR 请提交到 dev 开发分支上

-->