### PR TITLE
切换大纲后不让编辑器获得焦点

### DIFF
--- a/src/ts/outline/index.ts
+++ b/src/ts/outline/index.ts
@@ -39,7 +39,8 @@ export class Outline {
             if (vditor[vditor.currentMode].element.contains(range.startContainer)) {
                 setSelectionFocus(range);
             } else {
-                vditor[vditor.currentMode].element.focus();
+                // 编辑器不需要获得焦点, 这会导致滚动位置被清空
+                // vditor[vditor.currentMode].element.focus();
             }
         }
         setPadding(vditor);


### PR DESCRIPTION
现在切换大纲后后会让编辑器获得焦点, 这里有点问题.

编辑容器没有焦点的情况下滚动了, 此时切换大纲会导致自动滚向顶部(因为focus默认就是到顶部).