### PR TITLE
添加ossToken函数，方便做oss直传时从后端获取token、key等信息添加到表单中

### DIFF
--- a/src/ts/upload/index.ts
+++ b/src/ts/upload/index.ts
@@ -203,6 +203,13 @@ const uploadFiles =
             formData.append(key, extraData[key]);
         }
 
+        if (vditor.options.upload.ossToken) {
+          const extraData = await vditor.options.upload.ossToken(fileList);
+          for (const key of Object.keys(extraData)) {
+            formData.append(key, extraData[key]);
+          }
+        }
+
         for (let i = 0, iMax = validateResult.length; i < iMax; i++) {
             formData.append(vditor.options.upload.fieldName, validateResult[i]);
         }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -387,6 +387,9 @@ interface IUpload {
 
     /** 图片地址上传后的回调  */
     linkToImgCallback?(responseText: string): void;
+
+    /**oss云存储前段直传，从后端获取token等额外信息 */
+    ossToken?(files: File[]):  Promise<{[key: string]: string | Blob}>;
 }
 
 /** @link https://ld246.com/article/1549638745630#options-toolbar */


### PR DESCRIPTION
添加ossToken函数，方便oss前段直传的时候从后端动态获取临时oss直传所需要的token、key等信息添加到extraData中

例如：
```
async ossToken(files) {
            const data = {"token":"","key":""}
            await that.$axios.post('后端获取token', {filename: files[0].name}).then(res => {
              data.key = res.Key
              data.token = res.Token
              return data
            })
          },
```
