### PR TITLE
fix: 修复preview.actions里面默认复制行为的错误提示

### DIFF
--- a/src/ts/preview/index.ts
+++ b/src/ts/preview/index.ts
@@ -39,7 +39,7 @@ export class Preview {
             tempElement.className = "vditor-reset";
             tempElement.appendChild(getSelection().getRangeAt(0).cloneContents());
 
-            this.copyToX(vditor, tempElement);
+            this.copyToX(vditor, tempElement, "default");
             event.preventDefault();
         });
         previewElement.addEventListener("click", (event: MouseEvent & { target: HTMLElement }) => {
@@ -275,6 +275,7 @@ export class Preview {
         setSelectionFocus(range);
         document.execCommand("copy");
         this.element.lastElementChild.remove();
-        vditor.tip.show(`已复制，可到${type === "zhihu" ? "知乎" : "微信公众号平台"}进行粘贴`);
+        
+        vditor.tip.show(['zhihu', 'mp-wechat'].includes(type)? `已复制，可到${type === "zhihu" ? "知乎" : "微信公众号平台"}进行粘贴`: `已复制到剪切板`);
     }
 }


### PR DESCRIPTION
![image](https://github.com/Vanessa219/vditor/assets/32406368/6e6bc55e-ec40-451e-841b-759d0d161e73)
现在默认copy行为的提示是不正确, 因为只是复制到剪切板, 没有微信平台这些内容. 