### PR TITLE
:art: 支持自定义静态资源路径 #1465

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ class Vditor extends VditorMethod {
                         document.head.removeChild(el);
                     }
                 });
-                addScript(`${mergedOptions.cdn}/dist/js/i18n/${mergedOptions.lang}.js`, i18nScriptID).then(() => {
+                addScript(`${mergedOptions.staticPath.i18n}/${mergedOptions.lang}.js`, i18nScriptID).then(() => {
                     this.init(id as HTMLElement, mergedOptions);
                 });
             }
@@ -105,7 +105,7 @@ class Vditor extends VditorMethod {
         }
         if (codeTheme) {
             this.vditor.options.preview.hljs.style = codeTheme;
-            setCodeTheme(codeTheme, this.vditor.options.cdn);
+            setCodeTheme(codeTheme, this.vditor.options.staticPath.highlight);
         }
     }
 
@@ -441,7 +441,7 @@ class Vditor extends VditorMethod {
         });
     }
 
-    private init(id: HTMLElement, mergedOptions: IOptions) {
+    private init(id: HTMLElement, mergedOptions: IMergedOptions) {
         this.vditor = {
             currentMode: mergedOptions.mode,
             element: id,
@@ -473,7 +473,7 @@ class Vditor extends VditorMethod {
 
         addScript(
             mergedOptions._lutePath ||
-            `${mergedOptions.cdn}/dist/js/lute/lute.min.js`,
+            mergedOptions.staticPath.lute,
             "vditorLuteScript",
         ).then(() => {
             this.vditor.lute = setLute({
@@ -508,7 +508,10 @@ class Vditor extends VditorMethod {
             }
             if (mergedOptions.icon) {
                 // 防止初始化 2 个编辑器时加载 2 次
-                addScriptSync(`${mergedOptions.cdn}/dist/js/icons/${mergedOptions.icon}.js`, "vditorIconScript");
+                addScriptSync(
+                    `${mergedOptions.staticPath.icons}/${mergedOptions.icon}.js`,
+                    "vditorIconScript",
+                );
             }
         });
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+/// <reference types="./../types" />
 import "./assets/less/index.less";
 import VditorMethod from "./method";
 import {Constants, VDITOR_VERSION} from "./ts/constants";

--- a/src/ts/constants.ts
+++ b/src/ts/constants.ts
@@ -30,6 +30,54 @@ export abstract class Constants {
     "solidity", "yul"
   ];
   public static readonly CDN = `https://unpkg.com/vditor@${VDITOR_VERSION}`;
+  public static readonly DIST = "dist";
+  public static readonly BASE_URL = `${Constants.CDN}/${Constants.DIST}`;
+  public static readonly _STATIC_PATH = {
+    logo: "images/logo.png",
+    method: "method.min.js",
+    style: "index.css",
+
+    emoji: "images/emoji",
+    i18n: "js/i18n",
+    icons: "js/icons",
+    theme: "css/content-theme",
+
+    abc: "js/abcjs/abcjs_basic.min.js",
+    echarts: "js/echarts/echarts.min.js",
+    flowchart: "js/flowchart.js/flowchart.min.js",
+    graphviz: "js/graphviz/viz.js",
+    lute: "js/lute/lute.min.js",
+    markmap: "js/markmap/markmap.min.js",
+    mermaid: "js/mermaid/mermaid.min.js",
+    plantuml: "js/plantuml/plantuml-encoder.min.js",
+
+    highlight: "js/highlight.js",
+    katex: "js/katex",
+    mathjax: "js/mathjax",
+  } as const;
+  public static readonly STATIC_PATH = {
+    logo: `${Constants.BASE_URL}/${Constants._STATIC_PATH.logo}`,
+    method: `${Constants.BASE_URL}/${Constants._STATIC_PATH.method}`,
+    style: `${Constants.BASE_URL}/${Constants._STATIC_PATH.style}`,
+
+    emoji: `${Constants.BASE_URL}/${Constants._STATIC_PATH.emoji}`,
+    i18n: `${Constants.BASE_URL}/${Constants._STATIC_PATH.i18n}`,
+    icons: `${Constants.BASE_URL}/${Constants._STATIC_PATH.icons}`,
+    theme: `${Constants.BASE_URL}/${Constants._STATIC_PATH.theme}`,
+
+    abc: `${Constants.BASE_URL}/${Constants._STATIC_PATH.abc}`,
+    echarts: `${Constants.BASE_URL}/${Constants._STATIC_PATH.echarts}`,
+    flowchart: `${Constants.BASE_URL}/${Constants._STATIC_PATH.flowchart}`,
+    graphviz: `${Constants.BASE_URL}/${Constants._STATIC_PATH.graphviz}`,
+    lute: `${Constants.BASE_URL}/${Constants._STATIC_PATH.lute}`,
+    markmap: `${Constants.BASE_URL}/${Constants._STATIC_PATH.markmap}`,
+    mermaid: `${Constants.BASE_URL}/${Constants._STATIC_PATH.mermaid}`,
+    plantuml: `${Constants.BASE_URL}/${Constants._STATIC_PATH.plantuml}`,
+
+    highlight: `${Constants.BASE_URL}/${Constants._STATIC_PATH.highlight}`,
+    katex: `${Constants.BASE_URL}/${Constants._STATIC_PATH.katex}`,
+    mathjax: `${Constants.BASE_URL}/${Constants._STATIC_PATH.mathjax}`,
+  } as const;
   public static readonly MARKDOWN_OPTIONS = {
     autoSpace: false,
     gfmAutoLink: true,
@@ -44,18 +92,18 @@ export abstract class Constants {
     paragraphBeginningSpace: false,
     sanitize: true,
     toc: false,
-  };
+  } as const;
   public static readonly HLJS_OPTIONS = {
     enable: true,
     lineNumber: false,
     defaultLang: "",
     style: "github",
-  };
+  } as const;
   public static readonly MATH_OPTIONS: IMath = {
     engine: "KaTeX",
     inlineDigit: false,
     macros: {},
-  };
+  } as const;
   public static readonly THEME_OPTIONS = {
     current: "light",
     list: {
@@ -63,7 +111,7 @@ export abstract class Constants {
       "dark": "Dark",
       "light": "Light",
       "wechat": "WeChat",
-    },
-    path: `${Constants.CDN}/dist/css/content-theme`,
-  };
+    } as const,
+    path: Constants.STATIC_PATH.theme,
+  } as const;
 }

--- a/src/ts/devtools/index.ts
+++ b/src/ts/devtools/index.ts
@@ -20,7 +20,7 @@ export class DevTools {
             return;
         }
 
-        addScript(`${vditor.options.cdn}/dist/js/echarts/echarts.min.js`, "vditorEchartsScript").then(() => {
+        addScript(vditor.options.staticPath.echarts, "vditorEchartsScript").then(() => {
             if (!this.ASTChart) {
                 this.ASTChart = echarts.init(vditor.devtools.element.lastElementChild as HTMLDivElement);
             }

--- a/src/ts/export/index.ts
+++ b/src/ts/export/index.ts
@@ -25,8 +25,8 @@ export const exportPDF = (vditor: IVditor) => {
     vditor.tip.show(window.VditorI18n.generate, 3800);
     const iframe = document.querySelector("#vditorExportIframe") as HTMLIFrameElement;
     iframe.contentDocument.open();
-    iframe.contentDocument.write(`<link rel="stylesheet" href="${vditor.options.cdn}/dist/index.css"/>
-<script src="${vditor.options.cdn}/dist/method.min.js"></script>
+    iframe.contentDocument.write(`<link rel="stylesheet" href="${vditor.options.staticPath.style}"/>
+<script src="${vditor.options.staticPath.method}"></script>
 <div id="preview" style="width: 800px"></div>
 <script>
 window.addEventListener("message", (e) => {
@@ -34,6 +34,7 @@ window.addEventListener("message", (e) => {
     return;
   }
   Vditor.preview(document.getElementById('preview'), e.data, {
+    staticPath: ${JSON.stringify(vditor.options.staticPath)},
     markdown: {
       theme: "${vditor.options.preview.theme}"
     },
@@ -54,29 +55,30 @@ window.addEventListener("message", (e) => {
 
 export const exportHTML = (vditor: IVditor) => {
     const content = getHTML(vditor);
-    const html = `<html><head><link rel="stylesheet" type="text/css" href="${vditor.options.cdn}/dist/index.css"/>
-<script src="${vditor.options.cdn}/dist/js/i18n/${vditor.options.lang}.js"></script>
-<script src="${vditor.options.cdn}/dist/method.min.js"></script></head>
+    const html = `<html><head><link rel="stylesheet" type="text/css" href="${vditor.options.staticPath.style}"/>
+<script src="${vditor.options.staticPath.i18n}/${vditor.options.lang}.js"></script>
+<script src="${vditor.options.staticPath.method}"></script></head>
 <body><div class="vditor-reset" id="preview">${content}</div>
 <script>
     const previewElement = document.getElementById('preview')
     Vditor.setContentTheme('${vditor.options.preview.theme.current}', '${vditor.options.preview.theme.path}');
     Vditor.codeRender(previewElement);
-    Vditor.highlightRender(${JSON.stringify(vditor.options.preview.hljs)}, previewElement, '${vditor.options.cdn}');
+    Vditor.highlightRender(${JSON.stringify(vditor.options.preview.hljs)}, previewElement, '${vditor.options.staticPath.highlight}');
     Vditor.mathRender(previewElement, {
-        cdn: '${vditor.options.cdn}',
+        katex: '${vditor.options.staticPath.katex}',
+        mathjax: '${vditor.options.staticPath.mathjax}',
         math: ${JSON.stringify(vditor.options.preview.math)},
     });
-    Vditor.mermaidRender(previewElement, '${vditor.options.cdn}', '${vditor.options.theme}');
-    Vditor.markmapRender(previewElement, '${vditor.options.cdn}', '${vditor.options.theme}');
-    Vditor.flowchartRender(previewElement, '${vditor.options.cdn}');
-    Vditor.graphvizRender(previewElement, '${vditor.options.cdn}');
-    Vditor.chartRender(previewElement, '${vditor.options.cdn}', '${vditor.options.theme}');
-    Vditor.mindmapRender(previewElement, '${vditor.options.cdn}', '${vditor.options.theme}');
-    Vditor.abcRender(previewElement, '${vditor.options.cdn}');
+    Vditor.mermaidRender(previewElement, '${vditor.options.staticPath.mermaid}', '${vditor.options.theme}');
+    Vditor.markmapRender(previewElement, '${vditor.options.staticPath.markmap}', '${vditor.options.theme}');
+    Vditor.flowchartRender(previewElement, '${vditor.options.staticPath.flowchart}');
+    Vditor.graphvizRender(previewElement, '${vditor.options.staticPath.graphviz}');
+    Vditor.chartRender(previewElement, '${vditor.options.staticPath.echarts}', '${vditor.options.theme}');
+    Vditor.mindmapRender(previewElement, '${vditor.options.staticPath.echarts}', '${vditor.options.theme}');
+    Vditor.abcRender(previewElement, '${vditor.options.staticPath.abc}');
     Vditor.mediaRender(previewElement);
     Vditor.speechRender(previewElement);
 </script>
-<script src="${vditor.options.cdn}/dist/js/icons/${vditor.options.icon}.js"></script></body></html>`;
+<script src="${vditor.options.staticPath.icons}/${vditor.options.icon}.js"></script></body></html>`;
     download(vditor, html, content.substr(0, 10) + ".html");
 };

--- a/src/ts/markdown/abcRender.ts
+++ b/src/ts/markdown/abcRender.ts
@@ -6,10 +6,13 @@ declare const ABCJS: {
     renderAbc(element: HTMLElement, text: string): void;
 };
 
-export const abcRender = (element: (HTMLElement | Document) = document, cdn = Constants.CDN) => {
+export const abcRender = (
+    element: (HTMLElement | Document) = document,
+    abcPath: string = Constants.STATIC_PATH.abc,
+) => {
     const abcElements = abcRenderAdapter.getElements(element);
     if (abcElements.length > 0) {
-        addScript(`${cdn}/dist/js/abcjs/abcjs_basic.min.js`, "vditorAbcjsScript").then(() => {
+        addScript(abcPath, "vditorAbcjsScript").then(() => {
             abcElements.forEach((item: HTMLDivElement) => {
                 if (item.parentElement.classList.contains("vditor-wysiwyg__pre") ||
                     item.parentElement.classList.contains("vditor-ir__marker--pre")) {

--- a/src/ts/markdown/chartRender.ts
+++ b/src/ts/markdown/chartRender.ts
@@ -6,10 +6,14 @@ declare const echarts: {
     init(element: HTMLElement, theme?: string): IEChart;
 };
 
-export const chartRender = (element: (HTMLElement | Document) = document, cdn = Constants.CDN, theme: string) => {
+export const chartRender = (
+    element: (HTMLElement | Document) = document,
+    echartsPath: string = Constants.STATIC_PATH.echarts,
+    theme: string,
+) => {
     const echartsElements = chartRenderAdapter.getElements(element);
     if (echartsElements.length > 0) {
-        addScript(`${cdn}/dist/js/echarts/echarts.min.js`, "vditorEchartsScript").then(() => {
+        addScript(echartsPath, "vditorEchartsScript").then(() => {
             echartsElements.forEach((e: HTMLDivElement) => {
                 if (e.parentElement.classList.contains("vditor-wysiwyg__pre") ||
                     e.parentElement.classList.contains("vditor-ir__marker--pre")) {

--- a/src/ts/markdown/flowchartRender.ts
+++ b/src/ts/markdown/flowchartRender.ts
@@ -6,12 +6,15 @@ declare const flowchart: {
     parse(text: string): { drawSVG: (type: HTMLElement) => void };
 };
 
-export const flowchartRender = (element: HTMLElement, cdn = Constants.CDN) => {
+export const flowchartRender = (
+    element: HTMLElement,
+    flowchartPath: string = Constants.STATIC_PATH.flowchart,
+) => {
     const flowchartElements = flowchartRenderAdapter.getElements(element);
     if (flowchartElements.length === 0) {
         return;
     }
-    addScript(`${cdn}/dist/js/flowchart.js/flowchart.min.js`, "vditorFlowchartScript").then(() => {
+    addScript(flowchartPath, "vditorFlowchartScript").then(() => {
         flowchartElements.forEach((item: HTMLElement) => {
             if (item.getAttribute("data-processed") === "true") {
                 return;

--- a/src/ts/markdown/graphvizRender.ts
+++ b/src/ts/markdown/graphvizRender.ts
@@ -8,13 +8,16 @@ declare class Viz {
     constructor({ }: { worker: Worker });
 }
 
-export const graphvizRender = (element: HTMLElement, cdn = Constants.CDN) => {
+export const graphvizRender = (
+    element: HTMLElement,
+    graphvizPath: string = Constants.STATIC_PATH.graphviz,
+) => {
     const graphvizElements = graphvizRenderAdapter.getElements(element);
 
     if (graphvizElements.length === 0) {
         return;
     }
-    addScript(`${cdn}/dist/js/graphviz/viz.js`, "vditorGraphVizScript").then(() => {
+    addScript(graphvizPath, "vditorGraphVizScript").then(() => {
         graphvizElements.forEach((e: HTMLDivElement) => {
             const code = graphvizRenderAdapter.getCode(e);
             if (e.parentElement.classList.contains("vditor-wysiwyg__pre") ||

--- a/src/ts/markdown/highlightRender.ts
+++ b/src/ts/markdown/highlightRender.ts
@@ -6,18 +6,21 @@ declare const hljs: {
     highlightElement(element: Element): void;
 };
 
-export const highlightRender = (hljsOption?: IHljs, element: HTMLElement | Document = document,
-                                cdn = Constants.CDN) => {
+export const highlightRender = (
+    hljsOption?: IHljs,
+    element: HTMLElement | Document = document,
+    highlightPath: string = Constants.STATIC_PATH.highlight,
+) => {
     let style = hljsOption.style;
     if (!Constants.CODE_THEME.includes(style)) {
         style = "github";
     }
     const vditorHljsStyle = document.getElementById("vditorHljsStyle") as HTMLLinkElement;
-    const href = `${cdn}/dist/js/highlight.js/styles/${style}.css`;
+    const href = `${highlightPath}/styles/${style}.css`;
     if (vditorHljsStyle && vditorHljsStyle.href !== href) {
         vditorHljsStyle.remove();
     }
-    addStyle(`${cdn}/dist/js/highlight.js/styles/${style}.css`, "vditorHljsStyle");
+    addStyle(`${highlightPath}/styles/${style}.css`, "vditorHljsStyle");
 
     if (hljsOption.enable === false) {
         return;
@@ -28,9 +31,9 @@ export const highlightRender = (hljsOption?: IHljs, element: HTMLElement | Docum
         return;
     }
 
-    addScript(`${cdn}/dist/js/highlight.js/highlight.pack.js`, "vditorHljsScript").then(() => {
-        addScript(`${cdn}/dist/js/highlight.js/solidity.min.js`, "vditorHljsSolidityScript").then(() => {
-            addScript(`${cdn}/dist/js/highlight.js/yul.min.js`, "vditorHljsYulScript").then(() => {
+    addScript(`${highlightPath}/highlight.pack.js`, "vditorHljsScript").then(() => {
+        addScript(`${highlightPath}/solidity.min.js`, "vditorHljsSolidityScript").then(() => {
+            addScript(`${highlightPath}/yul.min.js`, "vditorHljsYulScript").then(() => {
                 element.querySelectorAll("pre > code").forEach((block) => {
                     // ir & wysiwyg 区域不渲染
                     if (block.parentElement.classList.contains("vditor-ir__marker--pre") ||

--- a/src/ts/markdown/markmapRender.ts
+++ b/src/ts/markdown/markmapRender.ts
@@ -32,12 +32,16 @@ const init = (el: HTMLElement,code: string) => {
   }
 
 
-export const markmapRender = (element: HTMLElement, cdn = Constants.CDN, theme: string) => {
+export const markmapRender = (
+    element: HTMLElement,
+    markmapPath: string = Constants.STATIC_PATH.markmap,
+    theme: string,
+) => {
     const markmapElements = markmapRenderAdapter.getElements(element);
     if (markmapElements.length === 0) {
         return;
     }
-    addScript(`${cdn}/dist/js/markmap/markmap.min.js`, "vditorMermaidScript").then(() => {
+    addScript(markmapPath, "vditorMermaidScript").then(() => {
         markmapElements.forEach((item) => {
             const code = markmapRenderAdapter.getCode(item);
             if (item.getAttribute("data-processed") === "true" || code.trim() === "") {

--- a/src/ts/markdown/mathRender.ts
+++ b/src/ts/markdown/mathRender.ts
@@ -17,7 +17,13 @@ declare global {
     }
 }
 
-export const mathRender = (element: HTMLElement, options?: { cdn?: string, math?: IMath }) => {
+export const mathRender = (
+    element: HTMLElement,
+    options?: {
+        katex?: string,
+        mathjax?: string,
+        math?: IMath,
+    }) => {
     const mathElements = mathRenderAdapter.getElements(element);
 
     if (mathElements.length === 0) {
@@ -25,7 +31,8 @@ export const mathRender = (element: HTMLElement, options?: { cdn?: string, math?
     }
 
     const defaultOptions = {
-        cdn: Constants.CDN,
+        katex: Constants.STATIC_PATH.katex,
+        mathjax: Constants.STATIC_PATH.mathjax,
         math: {
             engine: "KaTeX",
             inlineDigit: false,
@@ -40,9 +47,9 @@ export const mathRender = (element: HTMLElement, options?: { cdn?: string, math?
     options = Object.assign({}, defaultOptions, options);
 
     if (options.math.engine === "KaTeX") {
-        addStyle(`${options.cdn}/dist/js/katex/katex.min.css`, "vditorKatexStyle");
-        addScript(`${options.cdn}/dist/js/katex/katex.min.js`, "vditorKatexScript").then(() => {
-            addScript(`${options.cdn}/dist/js/katex/mhchem.min.js`, "vditorKatexChemScript").then(() => {
+        addStyle(`${options.katex}/katex.min.css`, "vditorKatexStyle");
+        addScript(`${options.katex}/katex.min.js`, "vditorKatexScript").then(() => {
+            addScript(`${options.katex}/mhchem.min.js`, "vditorKatexChemScript").then(() => {
                 mathElements.forEach((mathElement) => {
                     if (mathElement.parentElement.classList.contains("vditor-wysiwyg__pre") ||
                         mathElement.parentElement.classList.contains("vditor-ir__marker--pre")) {
@@ -90,7 +97,7 @@ export const mathRender = (element: HTMLElement, options?: { cdn?: string, math?
         if (!window.MathJax) {
             window.MathJax = {
                 loader: {
-                    paths: {mathjax: `${options.cdn}/dist/js/mathjax`},
+                    paths: {mathjax: options.mathjax},
                 },
                 startup: {
                     typeset: false,
@@ -103,7 +110,7 @@ export const mathRender = (element: HTMLElement, options?: { cdn?: string, math?
             Object.assign(window.MathJax, options.math.mathJaxOptions);
         }
         // 循环加载会抛异常
-        addScriptSync(`${options.cdn}/dist/js/mathjax/tex-svg-full.js`, "protyleMathJaxScript");
+        addScriptSync(`${options.mathjax}/tex-svg-full.js`, "protyleMathJaxScript");
         const renderMath = (mathElement: Element, next?: () => void) => {
             const math = code160to32(mathElement.textContent).trim();
             const mathOptions = window.MathJax.getMetricsFor(mathElement);

--- a/src/ts/markdown/mermaidRender.ts
+++ b/src/ts/markdown/mermaidRender.ts
@@ -7,12 +7,16 @@ declare const mermaid: {
     init(options: any, element: Element): void,
 };
 
-export const mermaidRender = (element: HTMLElement, cdn = Constants.CDN, theme: string) => {
+export const mermaidRender = (
+    element: HTMLElement,
+    mermaidPath: string = Constants.STATIC_PATH.mermaid,
+    theme: string,
+) => {
     const mermaidElements = mermaidRenderAdapter.getElements(element);
     if (mermaidElements.length === 0) {
         return;
     }
-    addScript(`${cdn}/dist/js/mermaid/mermaid.min.js`, "vditorMermaidScript").then(() => {
+    addScript(mermaidPath, "vditorMermaidScript").then(() => {
         const config: any = {
             securityLevel: "loose", // 升级后无 https://github.com/siyuan-note/siyuan/issues/3587，可使用该选项
             altFontFamily: "sans-serif",

--- a/src/ts/markdown/mindmapRender.ts
+++ b/src/ts/markdown/mindmapRender.ts
@@ -6,10 +6,14 @@ declare const echarts: {
     init(element: HTMLElement, theme?: string): IEChart;
 };
 
-export const mindmapRender = (element: (HTMLElement | Document) = document, cdn = Constants.CDN, theme: string) => {
+export const mindmapRender = (
+    element: (HTMLElement | Document) = document,
+    echartsPath: string = Constants.STATIC_PATH.echarts,
+    theme: string,
+) => {
     const mindmapElements = mindmapRenderAdapter.getElements(element);
     if (mindmapElements.length > 0) {
-        addScript(`${cdn}/dist/js/echarts/echarts.min.js`, "vditorEchartsScript").then(() => {
+        addScript(echartsPath, "vditorEchartsScript").then(() => {
             mindmapElements.forEach((e: HTMLDivElement) => {
                 if (e.parentElement.classList.contains("vditor-wysiwyg__pre") ||
                     e.parentElement.classList.contains("vditor-ir__marker--pre")) {

--- a/src/ts/markdown/outlineRender.ts
+++ b/src/ts/markdown/outlineRender.ts
@@ -56,7 +56,8 @@ export const outlineRender = (contentElement: HTMLElement, targetElement: Elemen
     targetElement.innerHTML = tocHTML;
     if (vditor) {
         mathRender(targetElement as HTMLElement, {
-            cdn: vditor.options.cdn,
+            katex: vditor.options.staticPath.katex,
+            mathjax: vditor.options.staticPath.mathjax,
             math: vditor.options.preview.math,
         });
     }

--- a/src/ts/markdown/plantumlRender.ts
+++ b/src/ts/markdown/plantumlRender.ts
@@ -6,12 +6,15 @@ declare const plantumlEncoder: {
     encode(options: string): string,
 };
 
-export const plantumlRender = (element: (HTMLElement | Document) = document, cdn = Constants.CDN) => {
+export const plantumlRender = (
+    element: (HTMLElement | Document) = document,
+    plantumlPath: string = Constants.STATIC_PATH.plantuml,
+) => {
     const plantumlElements = plantumlRenderAdapter.getElements(element);
     if (plantumlElements.length === 0) {
         return;
     }
-    addScript(`${cdn}/dist/js/plantuml/plantuml-encoder.min.js`, "vditorPlantumlScript").then(() => {
+    addScript(plantumlPath, "vditorPlantumlScript").then(() => {
         plantumlElements.forEach((e: HTMLDivElement) => {
             if (e.parentElement.classList.contains("vditor-wysiwyg__pre") ||
                 e.parentElement.classList.contains("vditor-ir__marker--pre")) {

--- a/src/ts/markdown/previewRender.ts
+++ b/src/ts/markdown/previewRender.ts
@@ -24,10 +24,12 @@ const mergeOptions = (options?: IPreviewOptions) => {
     const defaultOption: IPreviewOptions = {
         anchor: 0,
         cdn: Constants.CDN,
+        dist: Constants.DIST,
+        staticPath: Constants.STATIC_PATH,
         customEmoji: {},
         emojiPath: `${
             (options && options.emojiPath) || Constants.CDN
-        }/dist/images/emoji`,
+        }/${Constants.DIST}/${Constants._STATIC_PATH.emoji}`,
         hljs: Constants.HLJS_OPTIONS,
         icon: "ant",
         lang: "zh_CN",
@@ -44,7 +46,7 @@ const mergeOptions = (options?: IPreviewOptions) => {
 
 export const md2html = (mdText: string, options?: IPreviewOptions) => {
     const mergedOptions = mergeOptions(options);
-    return addScript(`${mergedOptions.cdn}/dist/js/lute/lute.min.js`, "vditorLuteScript").then(() => {
+    return addScript(mergedOptions.staticPath.lute, "vditorLuteScript").then(() => {
         const lute = setLute({
             autoSpace: mergedOptions.markdown.autoSpace,
             gfmAutoLink: mergedOptions.markdown.gfmAutoLink,
@@ -99,14 +101,14 @@ export const previewRender = async (previewElement: HTMLDivElement, markdown: st
                     document.head.removeChild(el);
                 }
             });
-            await addScript(`${mergedOptions.cdn}/dist/js/i18n/${mergedOptions.lang}.js`, i18nScriptID);
+            await addScript(`${mergedOptions.staticPath.i18n}/${mergedOptions.lang}.js`, i18nScriptID);
         }
     } else {
         window.VditorI18n = mergedOptions.i18n;
     }
 
     if (mergedOptions.icon) {
-        await addScript(`${mergedOptions.cdn}/dist/js/icons/${mergedOptions.icon}.js`, "vditorIconScript");
+        await addScript(`${mergedOptions.staticPath.icons}/${mergedOptions.icon}.js`, "vditorIconScript");
     }
 
     setContentTheme(mergedOptions.theme.current, mergedOptions.theme.path);
@@ -114,19 +116,52 @@ export const previewRender = async (previewElement: HTMLDivElement, markdown: st
         previewElement.classList.add("vditor-reset--anchor");
     }
     codeRender(previewElement);
-    highlightRender(mergedOptions.hljs, previewElement, mergedOptions.cdn);
+    highlightRender(
+        mergedOptions.hljs,
+        previewElement,
+        mergedOptions.staticPath.highlight,
+    );
     mathRender(previewElement, {
-        cdn: mergedOptions.cdn,
+        katex: mergedOptions.staticPath.katex,
+        mathjax: mergedOptions.staticPath.mathjax,
         math: mergedOptions.math,
     });
-    mermaidRender(previewElement, mergedOptions.cdn, mergedOptions.mode);
-    markmapRender(previewElement, mergedOptions.cdn, mergedOptions.mode);
-    flowchartRender(previewElement, mergedOptions.cdn);
-    graphvizRender(previewElement, mergedOptions.cdn);
-    chartRender(previewElement, mergedOptions.cdn, mergedOptions.mode);
-    mindmapRender(previewElement, mergedOptions.cdn, mergedOptions.mode);
-    plantumlRender(previewElement, mergedOptions.cdn);
-    abcRender(previewElement, mergedOptions.cdn);
+    mermaidRender(
+        previewElement,
+        mergedOptions.staticPath.mermaid,
+        mergedOptions.mode,
+    );
+    markmapRender(
+        previewElement,
+        mergedOptions.staticPath.markmap,
+        mergedOptions.mode,
+    );
+    flowchartRender(
+        previewElement,
+        mergedOptions.staticPath.flowchart,
+    );
+    graphvizRender(
+        previewElement,
+        mergedOptions.staticPath.graphviz,
+    );
+    chartRender(
+        previewElement,
+        mergedOptions.staticPath.echarts,
+        mergedOptions.mode,
+    );
+    mindmapRender(
+        previewElement,
+        mergedOptions.staticPath.echarts,
+        mergedOptions.mode,
+    );
+    plantumlRender(
+        previewElement,
+        mergedOptions.staticPath.plantuml,
+    );
+    abcRender(
+        previewElement,
+        mergedOptions.staticPath.abc,
+    );
     mediaRender(previewElement);
     if (mergedOptions.speech.enable) {
         speechRender(previewElement);

--- a/src/ts/outline/index.ts
+++ b/src/ts/outline/index.ts
@@ -16,7 +16,7 @@ export class Outline {
     public render(vditor: IVditor) {
         let html = "";
         if (vditor.preview.element.style.display === "block") {
-            html = outlineRender(vditor.preview.element.lastElementChild as HTMLElement,
+            html = outlineRender(vditor.preview.previewElement as HTMLElement,
                 this.element.lastElementChild, vditor);
         } else {
             html = outlineRender(vditor[vditor.currentMode].element, this.element.lastElementChild, vditor);

--- a/src/ts/preview/index.ts
+++ b/src/ts/preview/index.ts
@@ -19,18 +19,20 @@ import {previewImage} from "./image";
 
 export class Preview {
     public element: HTMLElement;
+    public actionElement?: HTMLElement;
+    public previewElement: HTMLElement;
     private mdTimeoutId: number;
 
     constructor(vditor: IVditor) {
         this.element = document.createElement("div");
         this.element.className = `vditor-preview`;
-        const previewElement = document.createElement("div");
-        previewElement.className = "vditor-reset";
+        this.previewElement = document.createElement("div");
+        this.previewElement.className = "vditor-reset";
         if (vditor.options.classes.preview) {
-            previewElement.classList.add(vditor.options.classes.preview);
+            this.previewElement.classList.add(vditor.options.classes.preview);
         }
-        previewElement.style.maxWidth = vditor.options.preview.maxWidth + "px";
-        previewElement.addEventListener("copy", (event: ClipboardEvent & { target: HTMLElement }) => {
+        this.previewElement.style.maxWidth = vditor.options.preview.maxWidth + "px";
+        this.previewElement.addEventListener("copy", (event: ClipboardEvent & { target: HTMLElement }) => {
             if (event.target.tagName === "TEXTAREA") {
                 // https://github.com/Vanessa219/vditor/issues/901
                 return;
@@ -42,11 +44,11 @@ export class Preview {
             this.copyToX(vditor, tempElement, "default");
             event.preventDefault();
         });
-        previewElement.addEventListener("click", (event: MouseEvent & { target: HTMLElement }) => {
+        this.previewElement.addEventListener("click", (event: MouseEvent & { target: HTMLElement }) => {
             const spanElement = hasClosestByMatchTag(event.target, "SPAN");
             if (spanElement && hasClosestByClassName(spanElement, "vditor-toc")) {
                 const headingElement =
-                    previewElement.querySelector("#" + spanElement.getAttribute("data-target-id")) as HTMLElement;
+                    this.previewElement.querySelector("#" + spanElement.getAttribute("data-target-id")) as HTMLElement;
                 if (headingElement) {
                     this.element.scrollTop = headingElement.offsetTop;
                 }
@@ -69,13 +71,13 @@ export class Preview {
                 }
             }
         });
-        this.element.appendChild(previewElement);
+        this.element.appendChild(this.previewElement);
         const actions = vditor.options.preview.actions;
         if (actions.length === 0) {
             return;
         }
-        const actionElement = document.createElement("div");
-        actionElement.className = "vditor-preview__action";
+        this.actionElement = document.createElement("div");
+        this.actionElement.className = "vditor-preview__action";
         const actionHtml: string[] = [];
         for (let i = 0; i < actions.length; i++) {
             const action = actions[i];
@@ -101,9 +103,8 @@ export class Preview {
                     break;
             }
         }
-        actionElement.innerHTML = actionHtml.join("");
-        this.element.appendChild(actionElement);
-        actionElement.addEventListener(getEventName(), (event) => {
+        this.actionElement.innerHTML = actionHtml.join("");
+        this.actionElement.addEventListener(getEventName(), (event) => {
             const btn = hasClosestByTag(event.target as HTMLElement, "BUTTON");
             if (!btn) {
                 return;
@@ -116,26 +117,27 @@ export class Preview {
             }
 
             if (type === "mp-wechat" || type === "zhihu") {
-                this.copyToX(vditor, this.element.lastElementChild.cloneNode(true) as HTMLElement, type);
+                this.copyToX(vditor, this.previewElement.cloneNode(true) as HTMLElement, type);
                 return;
             }
 
             if (type === "desktop") {
-                previewElement.style.width = "auto";
+                this.previewElement.style.width = "auto";
             } else if (type === "tablet") {
-                previewElement.style.width = "780px";
+                this.previewElement.style.width = "780px";
             } else {
-                previewElement.style.width = "360px";
+                this.previewElement.style.width = "360px";
             }
-            if (previewElement.scrollWidth > previewElement.parentElement.clientWidth) {
-                previewElement.style.width = "auto";
+            if (this.previewElement.scrollWidth > this.previewElement.parentElement.clientWidth) {
+                this.previewElement.style.width = "auto";
             }
             this.render(vditor);
-            actionElement.querySelectorAll("button").forEach((item) => {
+            this.actionElement.querySelectorAll("button").forEach((item) => {
                 item.classList.remove("vditor-preview__action--current");
             });
             btn.classList.add("vditor-preview__action--current");
         });
+        this.element.insertBefore(this.actionElement, this.previewElement);
     }
 
     public render(vditor: IVditor, value?: string) {
@@ -149,13 +151,13 @@ export class Preview {
         }
 
         if (value) {
-            this.element.lastElementChild.innerHTML = value;
+            this.previewElement.innerHTML = value;
             return;
         }
 
         if (getMarkdown(vditor)
             .replace(/^[\s\uFEFF\xA0]+|[\s\uFEFF\xA0]+$/g, "") === "") {
-            this.element.lastElementChild.innerHTML = "";
+            this.previewElement.innerHTML = "";
             return;
         }
 
@@ -177,14 +179,14 @@ export class Preview {
                             if (vditor.options.preview.transform) {
                                 responseJSON.data = vditor.options.preview.transform(responseJSON.data);
                             }
-                            this.element.lastElementChild.innerHTML = responseJSON.data;
+                            this.previewElement.innerHTML = responseJSON.data;
                             this.afterRender(vditor, renderStartTime);
                         } else {
                             let html = vditor.lute.Md2HTML(markdownText);
                             if (vditor.options.preview.transform) {
                                 html = vditor.options.preview.transform(html);
                             }
-                            this.element.lastElementChild.innerHTML = html;
+                            this.previewElement.innerHTML = html;
                             this.afterRender(vditor, renderStartTime);
                         }
                     }
@@ -196,7 +198,7 @@ export class Preview {
                 if (vditor.options.preview.transform) {
                     html = vditor.options.preview.transform(html);
                 }
-                this.element.lastElementChild.innerHTML = html;
+                this.previewElement.innerHTML = html;
                 this.afterRender(vditor, renderStartTime);
             }
         }, vditor.options.preview.delay);
@@ -219,20 +221,20 @@ export class Preview {
         if (cmtFocusElement) {
             cmtFocusElement.classList.remove("vditor-comment--focus");
         }
-        codeRender(vditor.preview.element.lastElementChild as HTMLElement);
+        codeRender(vditor.preview.previewElement);
         highlightRender(
-            vditor.options.preview.hljs, vditor.preview.element.lastElementChild as HTMLElement,
+            vditor.options.preview.hljs, vditor.preview.previewElement,
             vditor.options.staticPath.highlight,
         );
-        mermaidRender(vditor.preview.element.lastElementChild as HTMLElement, vditor.options.staticPath.mermaid, vditor.options.theme);
-        markmapRender(vditor.preview.element.lastElementChild as HTMLElement, vditor.options.staticPath.markmap, vditor.options.theme);
-        flowchartRender(vditor.preview.element.lastElementChild as HTMLElement, vditor.options.staticPath.flowchart);
-        graphvizRender(vditor.preview.element.lastElementChild as HTMLElement, vditor.options.staticPath.graphviz);
-        chartRender(vditor.preview.element.lastElementChild as HTMLElement, vditor.options.staticPath.echarts, vditor.options.theme);
-        mindmapRender(vditor.preview.element.lastElementChild as HTMLElement, vditor.options.staticPath.echarts, vditor.options.theme);
-        plantumlRender(vditor.preview.element.lastElementChild as HTMLElement, vditor.options.staticPath.plantuml);
-        abcRender(vditor.preview.element.lastElementChild as HTMLElement, vditor.options.staticPath.abc);
-        mediaRender(vditor.preview.element.lastElementChild as HTMLElement);
+        mermaidRender(vditor.preview.previewElement, vditor.options.staticPath.mermaid, vditor.options.theme);
+        markmapRender(vditor.preview.previewElement, vditor.options.staticPath.markmap, vditor.options.theme);
+        flowchartRender(vditor.preview.previewElement, vditor.options.staticPath.flowchart);
+        graphvizRender(vditor.preview.previewElement, vditor.options.staticPath.graphviz);
+        chartRender(vditor.preview.previewElement, vditor.options.staticPath.echarts, vditor.options.theme);
+        mindmapRender(vditor.preview.previewElement, vditor.options.staticPath.echarts, vditor.options.theme);
+        plantumlRender(vditor.preview.previewElement, vditor.options.staticPath.plantuml);
+        abcRender(vditor.preview.previewElement, vditor.options.staticPath.abc);
+        mediaRender(vditor.preview.previewElement);
         // toc render
         const editorElement = vditor.preview.element;
         let tocHTML = vditor.outline.render(vditor);
@@ -247,7 +249,7 @@ export class Preview {
                 math: vditor.options.preview.math,
             });
         });
-        mathRender(vditor.preview.element.lastElementChild as HTMLElement, {
+        mathRender(vditor.preview.previewElement, {
             katex: vditor.options.staticPath.katex,
             mathjax: vditor.options.staticPath.mathjax,
             math: vditor.options.preview.math,
@@ -276,7 +278,7 @@ export class Preview {
         range.selectNode(copyElement);
         setSelectionFocus(range);
         document.execCommand("copy");
-        this.element.lastElementChild.remove();
+        copyElement.remove();
 
         vditor.tip.show(['zhihu', 'mp-wechat'].includes(type) ? `已复制，可到${type === "zhihu" ? "知乎" : "微信公众号平台"}进行粘贴` : `已复制到剪切板`);
     }

--- a/src/ts/preview/index.ts
+++ b/src/ts/preview/index.ts
@@ -220,16 +220,18 @@ export class Preview {
             cmtFocusElement.classList.remove("vditor-comment--focus");
         }
         codeRender(vditor.preview.element.lastElementChild as HTMLElement);
-        highlightRender(vditor.options.preview.hljs, vditor.preview.element.lastElementChild as HTMLElement,
-            vditor.options.cdn);
-        mermaidRender(vditor.preview.element.lastElementChild as HTMLElement, vditor.options.cdn, vditor.options.theme);
-        markmapRender(vditor.preview.element.lastElementChild as HTMLElement, vditor.options.cdn, vditor.options.theme);
-        flowchartRender(vditor.preview.element.lastElementChild as HTMLElement, vditor.options.cdn);
-        graphvizRender(vditor.preview.element.lastElementChild as HTMLElement, vditor.options.cdn);
-        chartRender(vditor.preview.element.lastElementChild as HTMLElement, vditor.options.cdn, vditor.options.theme);
-        mindmapRender(vditor.preview.element.lastElementChild as HTMLElement, vditor.options.cdn, vditor.options.theme);
-        plantumlRender(vditor.preview.element.lastElementChild as HTMLElement, vditor.options.cdn);
-        abcRender(vditor.preview.element.lastElementChild as HTMLElement, vditor.options.cdn);
+        highlightRender(
+            vditor.options.preview.hljs, vditor.preview.element.lastElementChild as HTMLElement,
+            vditor.options.staticPath.highlight,
+        );
+        mermaidRender(vditor.preview.element.lastElementChild as HTMLElement, vditor.options.staticPath.mermaid, vditor.options.theme);
+        markmapRender(vditor.preview.element.lastElementChild as HTMLElement, vditor.options.staticPath.markmap, vditor.options.theme);
+        flowchartRender(vditor.preview.element.lastElementChild as HTMLElement, vditor.options.staticPath.flowchart);
+        graphvizRender(vditor.preview.element.lastElementChild as HTMLElement, vditor.options.staticPath.graphviz);
+        chartRender(vditor.preview.element.lastElementChild as HTMLElement, vditor.options.staticPath.echarts, vditor.options.theme);
+        mindmapRender(vditor.preview.element.lastElementChild as HTMLElement, vditor.options.staticPath.echarts, vditor.options.theme);
+        plantumlRender(vditor.preview.element.lastElementChild as HTMLElement, vditor.options.staticPath.plantuml);
+        abcRender(vditor.preview.element.lastElementChild as HTMLElement, vditor.options.staticPath.abc);
         mediaRender(vditor.preview.element.lastElementChild as HTMLElement);
         // toc render
         const editorElement = vditor.preview.element;
@@ -240,12 +242,14 @@ export class Preview {
         editorElement.querySelectorAll('[data-type="toc-block"]').forEach((item: HTMLElement) => {
             item.innerHTML = tocHTML;
             mathRender(item, {
-                cdn: vditor.options.cdn,
+                katex: vditor.options.staticPath.katex,
+                mathjax: vditor.options.staticPath.mathjax,
                 math: vditor.options.preview.math,
             });
         });
         mathRender(vditor.preview.element.lastElementChild as HTMLElement, {
-            cdn: vditor.options.cdn,
+            katex: vditor.options.staticPath.katex,
+            mathjax: vditor.options.staticPath.mathjax,
             math: vditor.options.preview.math,
         });
     }

--- a/src/ts/toolbar/CodeTheme.ts
+++ b/src/ts/toolbar/CodeTheme.ts
@@ -24,7 +24,7 @@ export class CodeTheme extends MenuItem {
             if (event.target.tagName === "BUTTON") {
                 hidePanel(vditor, ["subToolbar"]);
                 vditor.options.preview.hljs.style = event.target.textContent;
-                setCodeTheme(event.target.textContent, vditor.options.cdn);
+                setCodeTheme(event.target.textContent, vditor.options.staticPath.highlight);
                 event.preventDefault();
                 event.stopPropagation();
             }

--- a/src/ts/toolbar/EditMode.ts
+++ b/src/ts/toolbar/EditMode.ts
@@ -70,7 +70,8 @@ export const setEditMode = (vditor: IVditor, type: string, event: Event | string
         });
         vditor.ir.element.querySelectorAll(".vditor-toc").forEach((item: HTMLElement) => {
             mathRender(item, {
-                cdn: vditor.options.cdn,
+                katex: vditor.options.staticPath.katex,
+                mathjax: vditor.options.staticPath.mathjax,
                 math: vditor.options.preview.math,
             });
         });
@@ -95,7 +96,8 @@ export const setEditMode = (vditor: IVditor, type: string, event: Event | string
         });
         vditor.wysiwyg.element.querySelectorAll(".vditor-toc").forEach((item: HTMLElement) => {
             mathRender(item, {
-                cdn: vditor.options.cdn,
+                katex: vditor.options.staticPath.katex,
+                mathjax: vditor.options.staticPath.mathjax,
                 math: vditor.options.preview.math,
             });
         });

--- a/src/ts/toolbar/Info.ts
+++ b/src/ts/toolbar/Info.ts
@@ -12,7 +12,7 @@ export class Info extends MenuItem {
     <em>下一代的 Markdown 编辑器，为未来而构建</em>
 </p>
 <div style="display: flex;margin-bottom: 14px;flex-wrap: wrap;align-items: center">
-    <img src="https://unpkg.com/vditor/dist/images/logo.png" style="margin: 0 auto;height: 68px"/>
+    <img src="${vditor.options.staticPath.logo}" style="margin: 0 auto;height: 68px"/>
     <div>&nbsp;&nbsp;</div>
     <div style="flex: 1;min-width: 250px">
         Vditor 是一款浏览器端的 Markdown 编辑器，支持所见即所得、即时渲染（类似 Typora）和分屏预览模式。

--- a/src/ts/ui/setCodeTheme.ts
+++ b/src/ts/ui/setCodeTheme.ts
@@ -1,12 +1,12 @@
 import {Constants} from "../constants";
 import {addStyle} from "../util/addStyle";
 
-export const setCodeTheme = (codeTheme: string, cdn = Constants.CDN) => {
+export const setCodeTheme = (codeTheme: string, highlightPath: string = Constants.STATIC_PATH.highlight) => {
     if (!Constants.CODE_THEME.includes(codeTheme)) {
         codeTheme = "github";
     }
     const vditorHljsStyle = document.getElementById("vditorHljsStyle") as HTMLLinkElement;
-    const href = `${cdn}/dist/js/highlight.js/styles/${codeTheme}.css`;
+    const href = `${highlightPath}/styles/${codeTheme}.css`;
     if (!vditorHljsStyle) {
         addStyle(href, "vditorHljsStyle");
     } else if (vditorHljsStyle.href !== href) {

--- a/src/ts/ui/setTheme.ts
+++ b/src/ts/ui/setTheme.ts
@@ -1,7 +1,12 @@
 export const setTheme = (vditor: IVditor) => {
-    if (vditor.options.theme === "dark") {
-        vditor.element.classList.add("vditor--dark");
-    } else {
-        vditor.element.classList.remove("vditor--dark");
+    switch (vditor.options.theme) {
+        case "dark":
+            vditor.element.classList.toggle("vditor--dark", true);
+            break;
+
+        case "classic":
+        default:
+            vditor.element.classList.toggle("vditor--dark", false);
+            break;
     }
 };

--- a/src/ts/util/Options.ts
+++ b/src/ts/util/Options.ts
@@ -10,6 +10,7 @@ export class Options {
             enable: true,
         },
         cdn: Constants.CDN,
+        dist: Constants.DIST,
         classes: {
             preview: "",
         },
@@ -37,7 +38,7 @@ export class Options {
                 "smile": "😄",
                 "tada": "🎉️",
             },
-            emojiPath: `${Constants.CDN}/dist/images/emoji`,
+            emojiPath: `${Constants.CDN}/${Constants.DIST}/images/emoji`,
             extend: [],
             parse: true,
         },
@@ -139,7 +140,7 @@ export class Options {
         this.options = options;
     }
 
-    public merge(): IOptions {
+    public merge(): IMergedOptions {
         if (this.options) {
             if (this.options.toolbar) {
                 this.options.toolbar = this.mergeToolbar(this.options.toolbar);
@@ -168,6 +169,31 @@ export class Options {
                 "need options.cache.id, see https://ld246.com/article/1549638745630#options",
             );
         }
+
+        mergedOptions.baseURL = mergedOptions._baseURL || `${mergedOptions.cdn}/${mergedOptions.dist}`;
+        mergedOptions.staticPath = merge({
+            logo: `${mergedOptions.baseURL}/${Constants._STATIC_PATH.logo}`,
+            method: `${mergedOptions.baseURL}/${Constants._STATIC_PATH.method}`,
+            style: `${mergedOptions.baseURL}/${Constants._STATIC_PATH.style}`,
+
+            emoji: `${mergedOptions.baseURL}/${Constants._STATIC_PATH.emoji}`,
+            i18n: `${mergedOptions.baseURL}/${Constants._STATIC_PATH.i18n}`,
+            icons: `${mergedOptions.baseURL}/${Constants._STATIC_PATH.icons}`,
+            theme: `${mergedOptions.baseURL}/${Constants._STATIC_PATH.theme}`,
+
+            abc: `${mergedOptions.baseURL}/${Constants._STATIC_PATH.abc}`,
+            echarts: `${mergedOptions.baseURL}/${Constants._STATIC_PATH.echarts}`,
+            flowchart: `${mergedOptions.baseURL}/${Constants._STATIC_PATH.flowchart}`,
+            graphviz: `${mergedOptions.baseURL}/${Constants._STATIC_PATH.graphviz}`,
+            lute: `${mergedOptions.baseURL}/${Constants._STATIC_PATH.lute}`,
+            markmap: `${mergedOptions.baseURL}/${Constants._STATIC_PATH.markmap}`,
+            mermaid: `${mergedOptions.baseURL}/${Constants._STATIC_PATH.mermaid}`,
+            plantuml: `${mergedOptions.baseURL}/${Constants._STATIC_PATH.plantuml}`,
+
+            highlight: `${mergedOptions.baseURL}/${Constants._STATIC_PATH.highlight}`,
+            katex: `${mergedOptions.baseURL}/${Constants._STATIC_PATH.katex}`,
+            mathjax: `${mergedOptions.baseURL}/${Constants._STATIC_PATH.mathjax}`,
+        } as IMergedOptions["staticPath"], mergedOptions._staticPath);
 
         return mergedOptions;
     }

--- a/src/ts/util/processCode.ts
+++ b/src/ts/util/processCode.ts
@@ -64,25 +64,33 @@ export const processCodeRender = (previewPanel: HTMLElement, vditor: IVditor) =>
     }
     const language = previewPanel.firstElementChild.className.replace("language-", "");
     if (language === "abc") {
-        abcRender(previewPanel, vditor.options.cdn);
+        abcRender(previewPanel, vditor.options.staticPath.abc);
     } else if (language === "mermaid") {
-        mermaidRender(previewPanel, vditor.options.cdn, vditor.options.theme);
+        mermaidRender(previewPanel, vditor.options.staticPath.mermaid, vditor.options.theme);
     } else if (language === "markmap") {
-        markmapRender(previewPanel, vditor.options.cdn, vditor.options.theme);
+        markmapRender(previewPanel, vditor.options.staticPath.markmap, vditor.options.theme);
     } else if (language === "flowchart") {
-        flowchartRender(previewPanel, vditor.options.cdn);
+        flowchartRender(previewPanel, vditor.options.staticPath.flowchart);
     } else if (language === "echarts") {
-        chartRender(previewPanel, vditor.options.cdn, vditor.options.theme);
+        chartRender(previewPanel, vditor.options.staticPath.echarts, vditor.options.theme);
     } else if (language === "mindmap") {
-        mindmapRender(previewPanel, vditor.options.cdn, vditor.options.theme);
+        mindmapRender(previewPanel, vditor.options.staticPath.echarts, vditor.options.theme);
     } else if (language === "plantuml") {
-        plantumlRender(previewPanel, vditor.options.cdn);
+        plantumlRender(previewPanel, vditor.options.staticPath.plantuml);
     } else if (language === "graphviz") {
-        graphvizRender(previewPanel, vditor.options.cdn);
+        graphvizRender(previewPanel, vditor.options.staticPath.graphviz);
     } else if (language === "math") {
-        mathRender(previewPanel, {cdn: vditor.options.cdn, math: vditor.options.preview.math});
+        mathRender(previewPanel, {
+            katex: vditor.options.staticPath.katex,
+            mathjax: vditor.options.staticPath.mathjax,
+            math: vditor.options.preview.math,
+        });
     } else {
-        highlightRender(Object.assign({}, vditor.options.preview.hljs), previewPanel, vditor.options.cdn);
+        highlightRender(
+            Object.assign({}, vditor.options.preview.hljs),
+            previewPanel,
+            vditor.options.staticPath.highlight,
+        );
         codeRender(previewPanel);
     }
 

--- a/src/ts/util/toc.ts
+++ b/src/ts/util/toc.ts
@@ -15,7 +15,8 @@ export const renderToc = (vditor: IVditor) => {
     editorElement.querySelectorAll('[data-type="toc-block"]').forEach((item: HTMLElement) => {
         item.innerHTML = tocHTML;
         mathRender(item, {
-            cdn: vditor.options.cdn,
+            katex: vditor.options.staticPath.katex,
+            mathjax: vditor.options.staticPath.mathjax,
             math: vditor.options.preview.math,
         });
     });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -481,11 +481,20 @@ interface IMarkdownConfig {
 
 /** @link https://ld246.com/article/1549638745630#options-preview */
 interface IPreview {
-    /** 预览 debounce 毫秒间隔。默认值: 1000 */
+    /** 
+     * 预览 debounce 毫秒间隔
+     * @default 1000
+     */
     delay?: number;
-    /** 预览区域最大宽度。默认值: 768 */
+    /** 
+     * 预览区域最大宽度
+     * @default 800
+     */
     maxWidth?: number;
-    /** 显示模式。默认值: 'both' */
+    /**
+     * 显示模式
+     * @default "both"
+     */
     mode?: "both" | "editor";
     /** md 解析请求 */
     url?: string;
@@ -497,7 +506,10 @@ interface IPreview {
     markdown?: IMarkdownConfig;
     /** @link https://ld246.com/article/1549638745630#options-preview-theme */
     theme?: IPreviewTheme;
-    /** @link https://ld246.com/article/1549638745630#options-preview-actions  */
+    /**
+     * @link https://ld246.com/article/1549638745630#options-preview-actions
+     * @default ["desktop", "tablet", "mobile", "mp-wechat", "zhihu"]
+     */
     actions?: Array<IPreviewAction | IPreviewActionCustom>;
 
     /** 预览回调 */
@@ -905,6 +917,8 @@ interface IVditor {
     };
     preview?: {
         element: HTMLElement
+        actionElement?: HTMLElement
+        previewElement: HTMLElement
         render(vditor: IVditor, value?: string): void,
     };
     counter?: {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -536,6 +536,8 @@ interface IPreviewOptions {
     anchor?: number; // 0: no render, 1: render left, 2: render right
     math?: IMath;
     cdn?: string;
+    dist?: string;
+    staticPath?: IStaticPath;
     markdown?: IMarkdownConfig;
     renderers?: ILuteRender;
     theme?: IPreviewTheme;
@@ -613,6 +615,112 @@ interface IResize {
     after?(height: number): void;
 }
 
+interface IStaticPath {
+    /** 
+     * 文件
+     * @default `${baseURL}/images/logo.png`
+     */
+    logo?: string;
+
+    /** 
+     * 文件
+     * @default `${baseURL}/method.min.js`
+     */
+    method?: string;
+
+    /** 
+     * 文件
+     * @default `${baseURL}/index.css`
+     */
+    style?: string;
+
+
+    /** 
+     * 目录
+     * @default `${baseURL}/images/emoji`
+     */
+    emoji?: string;
+
+    /** 
+     * 目录
+     * @default `${baseURL}/js/i18n`
+     */
+    i18n?: string;
+
+    /** 
+     * 目录
+     * @default `${baseURL}/js/icons`
+     */
+    icons?: string;
+
+    /** 
+     * 目录
+     * @default `${baseURL}/css/content-theme`
+     */
+    theme?: string;
+
+
+    /** 文件
+     * @default `${baseURL}/js/abcjs/abcjs_basic.js/abcjs/abcjs_basic.min.js`
+     */
+    abc?: string;
+
+    /** 文件
+     * @default `${baseURL}/js/echarts/echarts.min.js`
+     */
+    echarts?: string;
+
+    /** 文件
+     * @default `${baseURL}/js/js/flowchart.js/flowchart.min.js`
+     */
+    flowchart?: string;
+
+    /** 文件
+     * @default `${baseURL}/js/graphviz/viz.js`
+     */
+    graphviz?: string;
+
+    /** 文件
+     * @default `${baseURL}/js/lute/lute.min.js`
+     */
+    lute?: string;
+
+    /** 文件
+     * @default `${baseURL}/js/markmap/markmap.min.js`
+     */
+    markmap?: string;
+
+    /** 文件
+     * @default `${baseURL}/js/mermaid/mermaid.min.js`
+     */
+    mermaid?: string;
+
+    /** 文件
+     * @default `${baseURL}/js/plantuml/plantuml-encoder.min.js`
+     */
+    plantuml?: string;
+
+
+    /** 
+     * 目录
+     * @default `${baseURL}/js/highlight.js`
+     */
+    highlight?: string;
+
+    /** 
+     * 目录
+     * @default `${baseURL}/js/katex`
+     */
+    katex?: string;
+
+    /** 
+     * 目录
+     * @default `${baseURL}/js/mathjax`
+     */
+    mathjax?: string;
+}
+
+
 /** @link https://ld246.com/article/1549638745630#options */
 interface IOptions {
     /** RTL */
@@ -621,6 +729,18 @@ interface IOptions {
     undoDelay?: number;
     /** 内部调试时使用 */
     _lutePath?: string;
+    /**
+     * 自定义静态资源基础路径
+     * @default
+     * `${cdn}/${dist}`
+     * `${cdn}/dist`
+     * `https://unpkg.com/vditor@${VDITOR_VERSION}/dist`
+     */
+    _baseURL?: string,
+    /**
+     * 自定义静态资源路径
+     */
+    _staticPath?: IStaticPath,
     /** 编辑器初始化值。默认值: '' */
     value?: string;
     /** 是否显示日志。默认值: false */
@@ -718,6 +838,11 @@ interface IOptions {
     classes?: IClasses;
     /** 配置自建 CDN 地址。默认值: 'https://unpkg.com/vditor@${VDITOR_VERSION}' */
     cdn?: string;
+    /**
+     * 自定义 dist 目录路径
+     * @default "dist"
+     */
+    dist?: string,
     /** tab 键操作字符串，支持 \t 及任意字符串 */
     tab?: string;
     /** @link https://ld246.com/article/1549638745630#options-outline */
@@ -748,6 +873,11 @@ interface IOptions {
     select?(value: string): void;
 }
 
+interface IMergedOptions extends IOptions {
+    baseURL: string;
+    staticPath: Required<IStaticPath>;
+}
+
 interface IEChart {
     setOption(option: any): void;
 
@@ -756,7 +886,7 @@ interface IEChart {
 
 interface IVditor {
     element: HTMLElement;
-    options: IOptions;
+    options: IMergedOptions;
     originalInnerHTML: string;
     lute: Lute;
     currentMode: "sv" | "wysiwyg" | "ir";


### PR DESCRIPTION
<!--

* PR 请提交到 dev 开发分支上

-->

添加配置项以自定义静态资源的路径

- `dist`: 设置静态资源目录路径
- `_staticPath`: 各类静态资源文件的路径
  - `logo`: `images/logo.png`
  - `method`: `method.min.js`
  - `style`: `index.css`
  - `emoji`: `images/emoji`
  - `i18n`: `js/i18n`
  - `icons`: `js/icons`
  - `theme`: `css/content-theme`
  - `abc`: `js/abcjs/abcjs_basic.js/abcjs/abcjs_basic.min.js`
  - `echarts`: `js/echarts/echarts.min.js`
  - `flowchart`: `js/js/flowchart.js/flowchart.min.js`
  - `graphviz`: `js/graphviz/viz.js`
  - `lute`: `js/lute/lute.min.js`
  - `markmap`: `js/markmap/markmap.min.js`
  - `mermaid`: `js/mermaid/mermaid.min.js`
  - `plantuml`: `js/plantuml/plantuml-encoder.min.js`
  - `highlight`: `js/highlight.js`
  - `katex`: `js/katex`
  - `mathjax`: `js/mathjax`
