### PR TITLE
Fix the issue of confusing preview element and actions element

### DIFF
--- a/src/ts/outline/index.ts
+++ b/src/ts/outline/index.ts
@@ -16,7 +16,7 @@ export class Outline {
     public render(vditor: IVditor) {
         let html = "";
         if (vditor.preview.element.style.display === "block") {
-            html = outlineRender(vditor.preview.element.lastElementChild as HTMLElement,
+            html = outlineRender(vditor.preview.previewElement,
                 this.element.lastElementChild, vditor);
         } else {
             html = outlineRender(vditor[vditor.currentMode].element, this.element.lastElementChild, vditor);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -774,7 +774,9 @@ interface IVditor {
         element?: HTMLElement,
     };
     preview?: {
-        element: HTMLElement
+        element: HTMLElement,
+        actionElement?: HTMLElement,
+        previewElement: HTMLElement,
         render(vditor: IVditor, value?: string): void,
     };
     counter?: {


### PR DESCRIPTION
当前设置了 `options.preview.actions` 的预览页面的 `preview.element.lastElementChild` 指向了 `vditor-preview__action` 元素导致无法正常渲染, 现更改为使用 `preview.previeElement` 访问渲染内容容器