### PR TITLE
perf: 优化代码块的渲染性能

### DIFF
--- a/src/ts/markdown/codeRender.ts
+++ b/src/ts/markdown/codeRender.ts
@@ -2,32 +2,33 @@ import {code160to32} from "../util/code160to32";
 import {Constants} from "../constants";
 
 export const codeRender = (element: HTMLElement) => {
-    element.querySelectorAll("pre > code").forEach((e: HTMLElement, index: number) => {
+    Array.from<HTMLElement>(element.querySelectorAll("pre > code")).filter((e, index) => {
         if (e.parentElement.classList.contains("vditor-wysiwyg__pre") ||
             e.parentElement.classList.contains("vditor-ir__marker--pre")) {
-            return;
+            return false;
         }
         if (e.classList.contains("language-mermaid") || e.classList.contains("language-flowchart") ||
             e.classList.contains("language-echarts") || e.classList.contains("language-mindmap") ||
             e.classList.contains("language-plantuml") || e.classList.contains("language-markmap") ||
             e.classList.contains("language-abc") || e.classList.contains("language-graphviz") ||
             e.classList.contains("language-math")) {
-            return;
+                return false;
         }
 
         if (e.style.maxHeight.indexOf("px") > -1) {
-            return;
+            return false;
         }
 
         // 避免预览区在渲染后由于代码块过多产生性能问题 https://github.com/b3log/vditor/issues/67
         if (element.classList.contains("vditor-preview") && index > 5) {
-            return;
+            return false;
         }
-
-        let codeText = e.innerText;
+        return true;
+    })
+    .map((e) => ({ e, codeText: e.innerText }))
+    .forEach(({ e, codeText }) => {
         if (e.classList.contains("highlight-chroma")) {
-            const codeElement = document.createElement("code");
-            codeElement.innerHTML = e.innerHTML;
+            const codeElement = e.cloneNode(true) as HTMLElement;
             codeElement.querySelectorAll(".highlight-ln").forEach((item: HTMLElement) => {
                 item.remove();
             });


### PR DESCRIPTION
在预览内容很多且包含很多代码片段的文档时，加载速度非常慢，有时会让整个页面卡死。

浏览器的性能分析报告如下：

![20231121140553](https://github.com/Vanessa219/vditor/assets/1730073/2d951fa9-5873-4353-bf92-2ee7a82910b2)

布局耗时 36 秒，布局排班中的色块是分成很多段的，这说明触发了很多次布局。

点击跳转源码界面，e.innerText 这一行代码耗时最高：

![20231121140445](https://github.com/Vanessa219/vditor/assets/1730073/7ce6611a-59ff-4039-ac01-934e4ad09b84)

由此可看出每次 `e.before(divElement)` 后获取元素的 innerText 都会重新布局一次。

解决方法是改成先批量获取 innerText，然后再批量插入新元素。优化后的效果如下，耗时大幅减少。

![20231121134203](https://github.com/Vanessa219/vditor/assets/1730073/24591d56-a4fe-4a57-a737-8db7e35af460)

