### PR TITLE
修复SV模式下脚注下方输入文本出现渲染错误

### DIFF
--- a/src/ts/sv/inputEvent.ts
+++ b/src/ts/sv/inputEvent.ts
@@ -151,7 +151,8 @@ export const inputEvent = (vditor: IVditor, event?: InputEvent) => {
 
             // 添加脚注
             vditor.sv.element.querySelectorAll("[data-type='footnotes-link']").forEach((item, index) => {
-                if (index === 0 && item && !(blockElement as HTMLElement).isEqualNode(item.parentElement)) {
+                // 加入所有脚注便于渲染引用
+                if (item && !(blockElement as HTMLElement).isEqualNode(item.parentElement)) {
                     html += "\n" + item.parentElement.textContent;
                     item.parentElement.remove();
                 }
@@ -181,20 +182,10 @@ export const inputEvent = (vditor: IVditor, event?: InputEvent) => {
     }
 
     // 脚注合并后添加的末尾
-    let firstFootnoteElement: Element;
-    const allFootnoteElement = vditor.sv.element.querySelectorAll("[data-type='footnotes-link']");
-    allFootnoteElement.forEach((item, index) => {
-        if (index === 0) {
-            firstFootnoteElement = item.parentElement;
-        } else {
-            firstFootnoteElement.lastElementChild.remove();
-            firstFootnoteElement.insertAdjacentHTML("beforeend", `${item.parentElement.innerHTML}`);
-            item.parentElement.remove();
-        }
-    });
-    if (allFootnoteElement.length > 0) {
-        vditor.sv.element.insertAdjacentElement("beforeend", firstFootnoteElement);
-    }
+    vditor.sv.element.querySelectorAll("[data-type='footnotes-link']")
+        .forEach((item, index) => {
+            vditor.sv.element.insertAdjacentElement("beforeend", item.parentElement)
+        });
 
     setRangeByWbr(vditor.sv.element, range);
 

--- a/src/ts/sv/process.ts
+++ b/src/ts/sv/process.ts
@@ -17,14 +17,9 @@ export const processPaste = (vditor: IVditor, text: string) => {
         blockElement = vditor.sv.element;
     }
     let spinHTML = vditor.lute.SpinVditorSVDOM(blockElement.textContent)
-    if (spinHTML.indexOf('data-type="footnotes-link"') > -1 ||
-        spinHTML.indexOf('data-type="link-ref-defs-block"') > -1) {
-        spinHTML = "<div data-block='0'>" + spinHTML + "</div>";
-    } else {
-        spinHTML = "<div data-block='0'>" +
-            spinHTML.replace(/<span data-type="newline"><br \/><span style="display: none">\n<\/span><\/span><span data-type="newline"><br \/><span style="display: none">\n<\/span><\/span></g, '<span data-type="newline"><br /><span style="display: none">\n</span></span><span data-type="newline"><br /><span style="display: none">\n</span></span></div><div data-block="0"><') +
-            "</div>";
-    }
+    spinHTML = "<div data-block='0'>" +
+        spinHTML.replace(/<span data-type="newline"><br \/><span style="display: none">\n<\/span><\/span><span data-type="newline"><br \/><span style="display: none">\n<\/span><\/span></g, '<span data-type="newline"><br /><span style="display: none">\n</span></span><span data-type="newline"><br /><span style="display: none">\n</span></span></div><div data-block="0"><') +
+        "</div>";
     if (blockElement.isEqualNode(vditor.sv.element)) {
         blockElement.innerHTML = spinHTML;
     } else {
@@ -56,14 +51,9 @@ export const getSideByType = (spanNode: Node, type: string, isPrevious = true) =
 export const processSpinVditorSVDOM = (html: string, vditor: IVditor) => {
     log("SpinVditorSVDOM", html, "argument", vditor.options.debugger);
     const spinHTML = vditor.lute.SpinVditorSVDOM(html)
-    if (spinHTML.indexOf('data-type="footnotes-link"') > -1 ||
-        spinHTML.indexOf('data-type="link-ref-defs-block"') > -1) {
-        html = "<div data-block='0'>" + spinHTML + "</div>";
-    } else {
-        html = "<div data-block='0'>" +
-            spinHTML.replace(/<span data-type="newline"><br \/><span style="display: none">\n<\/span><\/span><span data-type="newline"><br \/><span style="display: none">\n<\/span><\/span></g, '<span data-type="newline"><br /><span style="display: none">\n</span></span><span data-type="newline"><br /><span style="display: none">\n</span></span></div><div data-block="0"><') +
-            "</div>";
-    }
+    html = "<div data-block='0'>" +
+        spinHTML.replace(/<span data-type="newline"><br \/><span style="display: none">\n<\/span><\/span><span data-type="newline"><br \/><span style="display: none">\n<\/span><\/span></g, '<span data-type="newline"><br /><span style="display: none">\n</span></span><span data-type="newline"><br /><span style="display: none">\n</span></span></div><div data-block="0"><') +
+        "</div>";
     log("SpinVditorSVDOM", html, "result", vditor.options.debugger);
     return html;
 };


### PR DESCRIPTION
尝试修复了下#1518，这个问题应该是在修复`1270`和`1269`时产生的，个人认为脚注自动复制全文对用户使用的影响更大，因此修复了下这个问题。

同样有关联的问题:https://github.com/Vanessa219/vditor/issues/1269#issuecomment-1208331988