### PR TITLE
修复了一些关于脚注的问题

### DIFF
--- a/src/ts/sv/inputEvent.ts
+++ b/src/ts/sv/inputEvent.ts
@@ -2,6 +2,7 @@ import {scrollCenter} from "../util/editorCommonEvent";
 import {hasClosestByAttribute} from "../util/hasClosest";
 import {getSelectPosition, setRangeByWbr} from "../util/selection";
 import {getSideByType, processAfterRender, processSpinVditorSVDOM} from "./process";
+import { combineFootnote } from "../util/combineFootnote"
 
 export const inputEvent = (vditor: IVditor, event?: InputEvent) => {
     const range = getSelection().getRangeAt(0).cloneRange();
@@ -181,11 +182,10 @@ export const inputEvent = (vditor: IVditor, event?: InputEvent) => {
         vditor.sv.element.insertAdjacentElement("beforeend", firstLinkRefDefElement);
     }
 
-    // 脚注合并后添加的末尾
-    vditor.sv.element.querySelectorAll("[data-type='footnotes-link']")
-        .forEach((item, index) => {
-            vditor.sv.element.insertAdjacentElement("beforeend", item.parentElement)
-        });
+    // 合并脚注
+    combineFootnote(vditor.sv.element, (root: HTMLElement) => {
+        vditor.sv.element.insertAdjacentElement("beforeend", root)
+    })
 
     setRangeByWbr(vditor.sv.element, range);
 

--- a/src/ts/sv/inputEvent.ts
+++ b/src/ts/sv/inputEvent.ts
@@ -149,14 +149,15 @@ export const inputEvent = (vditor: IVditor, event?: InputEvent) => {
                 }
             });
 
-            // 添加脚注
+            // 添加脚注到文章头，便于lute处理
+            let footnotes = ""
             vditor.sv.element.querySelectorAll("[data-type='footnotes-link']").forEach((item, index) => {
-                // 加入所有脚注便于渲染引用
                 if (item && !(blockElement as HTMLElement).isEqualNode(item.parentElement)) {
-                    html += "\n" + item.parentElement.textContent;
+                    footnotes += item.parentElement.textContent + "\n";
                     item.parentElement.remove();
                 }
             });
+            html = footnotes + html;
         }
     }
     html = processSpinVditorSVDOM(html, vditor);

--- a/src/ts/sv/inputEvent.ts
+++ b/src/ts/sv/inputEvent.ts
@@ -141,15 +141,16 @@ export const inputEvent = (vditor: IVditor, event?: InputEvent) => {
             blockElement.previousElementSibling.remove();
         }
         // 添加链接引用
+        let footnotes = ""
+
         vditor.sv.element.querySelectorAll("[data-type='link-ref-defs-block']").forEach((item, index) => {
             if (index === 0 && item && !(blockElement as HTMLElement).isEqualNode(item.parentElement)) {
-                html += "\n" + item.parentElement.textContent;
+                footnotes += item.parentElement.textContent + "\n";
                 item.parentElement.remove();
             }
         });
 
         // 添加脚注到文章头，便于lute处理
-        let footnotes = ""
         vditor.sv.element.querySelectorAll("[data-type='footnotes-link']").forEach((item, index) => {
             if (item && !(blockElement as HTMLElement).isEqualNode(item.parentElement)) {
                 footnotes += item.parentElement.textContent + "\n";

--- a/src/ts/sv/inputEvent.ts
+++ b/src/ts/sv/inputEvent.ts
@@ -140,25 +140,23 @@ export const inputEvent = (vditor: IVditor, event?: InputEvent) => {
             html = blockElement.previousElementSibling.textContent + html;
             blockElement.previousElementSibling.remove();
         }
-        if (!blockElement.innerText.startsWith("```")) {
-            // 添加链接引用
-            vditor.sv.element.querySelectorAll("[data-type='link-ref-defs-block']").forEach((item, index) => {
-                if (index === 0 && item && !(blockElement as HTMLElement).isEqualNode(item.parentElement)) {
-                    html += "\n" + item.parentElement.textContent;
-                    item.parentElement.remove();
-                }
-            });
+        // 添加链接引用
+        vditor.sv.element.querySelectorAll("[data-type='link-ref-defs-block']").forEach((item, index) => {
+            if (index === 0 && item && !(blockElement as HTMLElement).isEqualNode(item.parentElement)) {
+                html += "\n" + item.parentElement.textContent;
+                item.parentElement.remove();
+            }
+        });
 
-            // 添加脚注到文章头，便于lute处理
-            let footnotes = ""
-            vditor.sv.element.querySelectorAll("[data-type='footnotes-link']").forEach((item, index) => {
-                if (item && !(blockElement as HTMLElement).isEqualNode(item.parentElement)) {
-                    footnotes += item.parentElement.textContent + "\n";
-                    item.parentElement.remove();
-                }
-            });
-            html = footnotes + html;
-        }
+        // 添加脚注到文章头，便于lute处理
+        let footnotes = ""
+        vditor.sv.element.querySelectorAll("[data-type='footnotes-link']").forEach((item, index) => {
+            if (item && !(blockElement as HTMLElement).isEqualNode(item.parentElement)) {
+                footnotes += item.parentElement.textContent + "\n";
+                item.parentElement.remove();
+            }
+        });
+        html = footnotes + html;
     }
     html = processSpinVditorSVDOM(html, vditor);
     if (isSVElement) {

--- a/src/ts/sv/inputEvent.ts
+++ b/src/ts/sv/inputEvent.ts
@@ -145,7 +145,7 @@ export const inputEvent = (vditor: IVditor, event?: InputEvent) => {
         let footnotes = ""
 
         vditor.sv.element.querySelectorAll("[data-type='link-ref-defs-block']").forEach((item, index) => {
-            if (index === 0 && item && !(blockElement as HTMLElement).isEqualNode(item.parentElement)) {
+            if (item && !(blockElement as HTMLElement).isEqualNode(item.parentElement)) {
                 footnotes += item.parentElement.textContent + "\n";
                 item.parentElement.remove();
             }
@@ -167,20 +167,9 @@ export const inputEvent = (vditor: IVditor, event?: InputEvent) => {
         blockElement.outerHTML = html;
     }
 
-    let firstLinkRefDefElement: Element;
-    const allLinkRefDefsElement = vditor.sv.element.querySelectorAll("[data-type='link-ref-defs-block']");
-    allLinkRefDefsElement.forEach((item, index) => {
-        if (index === 0) {
-            firstLinkRefDefElement = item.parentElement;
-        } else {
-            firstLinkRefDefElement.lastElementChild.remove();
-            firstLinkRefDefElement.insertAdjacentHTML("beforeend", `${item.parentElement.innerHTML}`);
-            item.parentElement.remove();
-        }
-    });
-    if (allLinkRefDefsElement.length > 0) {
-        vditor.sv.element.insertAdjacentElement("beforeend", firstLinkRefDefElement);
-    }
+    vditor.sv.element.querySelectorAll("[data-type='link-ref-defs-block']").forEach((item) => {
+        vditor.sv.element.insertAdjacentElement("beforeend", item.parentElement)
+    })
 
     // 合并脚注
     combineFootnote(vditor.sv.element, (root: HTMLElement) => {

--- a/src/ts/sv/process.ts
+++ b/src/ts/sv/process.ts
@@ -6,42 +6,8 @@ import {hasClosestByTag} from "../util/hasClosestByHeadings";
 import {log} from "../util/log";
 import {getEditorRange, setRangeByWbr} from "../util/selection";
 import {inputEvent} from "./inputEvent";
+import { combineFootnote } from "../util/combineFootnote"
 
-/**
- * lute解析后处理
- * @param html lute解析后的文本
- */
-export const processAfterSpin = (html: string): string => {
-    // 合并块
-    html = "<div data-block='0'>" +
-        html.replace(/<span data-type="newline"><br \/><span style="display: none">\n<\/span><\/span><span data-type="newline"><br \/><span style="display: none">\n<\/span><\/span></g, '<span data-type="newline"><br /><span style="display: none">\n</span></span><span data-type="newline"><br /><span style="display: none">\n</span></span></div><div data-block="0"><') +
-        "</div>";
-    // 解析脚注，合并脚注块
-    const parser = document.createElement("div")
-    parser.innerHTML = html
-    parser.querySelectorAll("[data-type=footnotes-link]").forEach(el => {
-        const root = el.parentElement
-        let footnote = root.nextSibling
-        // 寻找所有该脚注的块
-        while (footnote) {
-            if (footnote.textContent.startsWith("    ")) {
-                // 解析到四个空格，加入到root并继续解析
-                const thisNode = footnote
-                thisNode.childNodes.forEach(node => {
-                    root.append(node.cloneNode(true))
-                })
-                footnote = footnote.nextSibling
-                thisNode.remove()
-            } else {
-                // 非空格停止解析
-                break
-            }
-        }
-    })
-    html = parser.innerHTML
-    parser.remove()
-    return html
-}
 
 export const processPaste = (vditor: IVditor, text: string) => {
     const range = getEditorRange(vditor);
@@ -53,12 +19,15 @@ export const processPaste = (vditor: IVditor, text: string) => {
         blockElement = vditor.sv.element;
     }
     let spinHTML = vditor.lute.SpinVditorSVDOM(blockElement.textContent)
-    spinHTML = processAfterSpin(spinHTML)
+    spinHTML = "<div data-block='0'>" +
+        spinHTML.replace(/<span data-type="newline"><br \/><span style="display: none">\n<\/span><\/span><span data-type="newline"><br \/><span style="display: none">\n<\/span><\/span></g, '<span data-type="newline"><br /><span style="display: none">\n</span></span><span data-type="newline"><br /><span style="display: none">\n</span></span></div><div data-block="0"><') +
+        "</div>";
     if (blockElement.isEqualNode(vditor.sv.element)) {
         blockElement.innerHTML = spinHTML;
     } else {
         blockElement.outerHTML = spinHTML;
     }
+    combineFootnote(vditor.sv.element)
     setRangeByWbr(vditor.sv.element, range);
 
     scrollCenter(vditor);
@@ -85,7 +54,9 @@ export const getSideByType = (spanNode: Node, type: string, isPrevious = true) =
 export const processSpinVditorSVDOM = (html: string, vditor: IVditor) => {
     log("SpinVditorSVDOM", html, "argument", vditor.options.debugger);
     const spinHTML = vditor.lute.SpinVditorSVDOM(html)
-    html = processAfterSpin(spinHTML)
+    html = "<div data-block='0'>" +
+        spinHTML.replace(/<span data-type="newline"><br \/><span style="display: none">\n<\/span><\/span><span data-type="newline"><br \/><span style="display: none">\n<\/span><\/span></g, '<span data-type="newline"><br /><span style="display: none">\n</span></span><span data-type="newline"><br /><span style="display: none">\n</span></span></div><div data-block="0"><') +
+        "</div>";
     log("SpinVditorSVDOM", html, "result", vditor.options.debugger);
     return html;
 };

--- a/src/ts/toolbar/EditMode.ts
+++ b/src/ts/toolbar/EditMode.ts
@@ -18,6 +18,7 @@ import {
     removeCurrentToolbar,
     showToolbar, toggleSubMenu,
 } from "./setToolbar";
+import { combineFootnote } from "../util/combineFootnote"
 
 export const setEditMode = (vditor: IVditor, type: string, event: Event | string) => {
     let markdownText;
@@ -122,6 +123,7 @@ export const setEditMode = (vditor: IVditor, type: string, event: Event | string
             svHTML = "";
         }
         vditor.sv.element.innerHTML = svHTML;
+        combineFootnote(vditor.sv.element)
         processSVAfterRender(vditor, {
             enableAddUndoStack: true,
             enableHint: false,

--- a/src/ts/util/combineFootnote.ts
+++ b/src/ts/util/combineFootnote.ts
@@ -1,0 +1,27 @@
+/**
+ * 合并脚注
+ * @param elements vditor.sv.element
+ * @param afterCombine 每个脚注块合并完成后的回调, param: root为合并后的脚注块
+ */
+export const combineFootnote = (elements: HTMLElement, afterCombine?: (root: HTMLElement) => void ) => {
+    elements.querySelectorAll("[data-type=footnotes-link]").forEach((el: Element) => {
+        const root = el.parentElement
+        let footnote = root.nextSibling
+        // 寻找所有该脚注的块
+        while (footnote) {
+            if (footnote.textContent.startsWith("    ")) {
+                // 解析到四个空格，加入到root并继续解析
+                const thisNode = footnote
+                thisNode.childNodes.forEach(node => {
+                    root.append(node.cloneNode(true))
+                })
+                footnote = footnote.nextSibling
+                thisNode.remove()
+            } else {
+                // 非空格停止解析
+                break
+            }
+        }
+        afterCombine && afterCombine(root)
+    })
+}


### PR DESCRIPTION
- 修复了 #1518 中所提到的脚注代码块会被文档提前的问题
- 修复 #1269 提到的 <```> 补全问题
- 修复了与 1518 类似的链接定义问题

## 修复手段

**1518**

通过在处理脚注脚注添加到末尾前对所属同一脚注的部分进行合并

**1269**

交由lute进行渲染前，将所有脚注提到待处理文本最上方，避免lute解析```时错误的将脚注作为主体内容解析

**链接定义问题**

同1518处理方式