### PR TITLE
feat: 新增unSelect事件回调

### DIFF
--- a/src/ts/util/editorCommonEvent.ts
+++ b/src/ts/util/editorCommonEvent.ts
@@ -254,6 +254,9 @@ export const selectEvent = (vditor: IVditor, editorElement: HTMLElement) => {
                     if (vditor.currentMode === "wysiwyg" && vditor.options.comment.enable) {
                         vditor.wysiwyg.hideComment();
                     }
+                    if (typeof vditor.options.unSelect === 'function') {
+                        vditor.options.unSelect();
+                    }
                 }
             });
         };


### PR DESCRIPTION
借用options.select自定义拓展选中浮窗，没有对应的钩子来隐藏浮窗，所以新增unSelect事件来进行隐藏。

<!--

* PR 请提交到 dev 开发分支上

-->