### PR TITLE
支持粘贴含有图文的 Word

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -400,6 +400,9 @@ interface IUpload {
     /** 自定义上传，当发生错误时返回错误信息 */
     handler?(files: File[]): string | null | Promise<string> | Promise<null>;
 
+    //将dataUrl上传到服务器，并返回获取数据的url
+    handleDataUrl?(dataUrl: string): string | Promise<string>;
+
     /** 对服务端返回的数据进行转换，以满足内置的数据结构 */
     format?(files: File[], responseText: string): string;
 


### PR DESCRIPTION
word复制的图文混合内容，把图片替换为dataUrl，解决复制word粘贴后图片丢失的问题。感谢ckeditor提供的思路和方法！
将dataUrl上传到服务器，并返回获取数据的url。解决md内容中由于大量base64而太长的问题。
