### PR TITLE
Refactor link creation logic in fixBrowserBehavior.ts

### DIFF
--- a/src/ts/util/fixBrowserBehavior.ts
+++ b/src/ts/util/fixBrowserBehavior.ts
@@ -1457,8 +1457,10 @@ export const paste = async (vditor: IVditor, event: (ClipboardEvent | DragEvent)
             }
         } else if (textPlain.trim() !== "" && files.length === 0) {
             const range = getEditorRange(vditor);
-            if (range.toString() !== "" && vditor.lute.IsValidLinkDest(textPlain)) {
-                textPlain = `[${range.toString()}](${textPlain})`;
+            const rangeText=range.toString();
+            if (vditor.lute.IsValidLinkDest(textPlain)) {
+                const title= rangeText ? rangeText : textPlain;
+                textPlain = `[${title}](${textPlain})`;
             }
             if (vditor.currentMode === "ir") {
                 renderers.Md2VditorIRDOM = {renderLinkDest};


### PR DESCRIPTION
粘贴超链接时，默认使用超链接地址当做标题

<!--

* PR 请提交到 dev 开发分支上

-->