### PR TITLE
fix: make undo work after recent edits

### DIFF
--- a/src/ts/ir/process.ts
+++ b/src/ts/ir/process.ts
@@ -48,6 +48,7 @@ export const processAfterRender = (vditor: IVditor, options = {
     clearTimeout(vditor.ir.processTimeoutId);
     vditor.ir.processTimeoutId = window.setTimeout(() => {
         if (vditor.ir.composingLock) {
+            vditor.ir.processTimeoutId = 0;
             return;
         }
         const text = getMarkdown(vditor);
@@ -73,6 +74,7 @@ export const processAfterRender = (vditor: IVditor, options = {
         if (options.enableAddUndoStack) {
             vditor.undo.addToUndoStack(vditor);
         }
+        vditor.ir.processTimeoutId = 0;
     }, vditor.options.undoDelay);
 };
 

--- a/src/ts/sv/process.ts
+++ b/src/ts/sv/process.ts
@@ -137,6 +137,7 @@ export const processAfterRender = (vditor: IVditor, options = {
         if (options.enableAddUndoStack && !vditor.sv.composingLock) {
             vditor.undo.addToUndoStack(vditor);
         }
+        vditor.sv.processTimeoutId = 0;
     }, vditor.options.undoDelay);
 };
 

--- a/src/ts/util/editorCommonEvent.ts
+++ b/src/ts/util/editorCommonEvent.ts
@@ -112,7 +112,49 @@ export const scrollCenter = (vditor: IVditor) => {
     }
 };
 
+const flushPendingUndoStack = (vditor: IVditor) => {
+    if (vditor.currentMode === "wysiwyg" && vditor.wysiwyg.afterRenderTimeoutId > 0) {
+        clearTimeout(vditor.wysiwyg.afterRenderTimeoutId);
+        vditor.wysiwyg.afterRenderTimeoutId = 0;
+        if (!vditor.wysiwyg.composingLock) {
+            vditor.undo.addToUndoStack(vditor);
+        }
+        return;
+    }
+
+    if (vditor.currentMode === "ir" && vditor.ir.processTimeoutId > 0) {
+        clearTimeout(vditor.ir.processTimeoutId);
+        vditor.ir.processTimeoutId = 0;
+        if (!vditor.ir.composingLock) {
+            vditor.undo.addToUndoStack(vditor);
+        }
+        return;
+    }
+
+    if (vditor.currentMode === "sv" && vditor.sv.processTimeoutId > 0) {
+        clearTimeout(vditor.sv.processTimeoutId);
+        vditor.sv.processTimeoutId = 0;
+        if (!vditor.sv.composingLock) {
+            vditor.undo.addToUndoStack(vditor);
+        }
+    }
+};
+
 export const hotkeyEvent = (vditor: IVditor, editorElement: HTMLElement) => {
+    editorElement.addEventListener("beforeinput", (event: InputEvent) => {
+        if (event.inputType !== "historyUndo" && event.inputType !== "historyRedo") {
+            return;
+        }
+
+        flushPendingUndoStack(vditor);
+        event.preventDefault();
+        if (event.inputType === "historyUndo") {
+            vditor.undo.undo(vditor);
+            return;
+        }
+        vditor.undo.redo(vditor);
+    });
+
     editorElement.addEventListener("keydown", (event: KeyboardEvent & { target: HTMLElement }) => {
         if (!event.isComposing && vditor.options.keydown) {
             vditor.options.keydown(event);
@@ -150,14 +192,16 @@ export const hotkeyEvent = (vditor: IVditor, editorElement: HTMLElement) => {
         }
 
         // undo
-        if (matchHotKey("⌘Z", event) && !vditor.toolbar.elements.undo) {
+        if (matchHotKey("⌘Z", event)) {
+            flushPendingUndoStack(vditor);
             vditor.undo.undo(vditor);
             event.preventDefault();
             return;
         }
 
         // redo
-        if (matchHotKey("⌘Y", event) && !vditor.toolbar.elements.redo) {
+        if (matchHotKey("⌘Y", event)) {
+            flushPendingUndoStack(vditor);
             vditor.undo.redo(vditor);
             event.preventDefault();
             return;

--- a/src/ts/wysiwyg/afterRenderEvent.ts
+++ b/src/ts/wysiwyg/afterRenderEvent.ts
@@ -12,6 +12,7 @@ export const afterRenderEvent = (vditor: IVditor, options = {
     clearTimeout(vditor.wysiwyg.afterRenderTimeoutId);
     vditor.wysiwyg.afterRenderTimeoutId = window.setTimeout(() => {
         if (vditor.wysiwyg.composingLock) {
+            vditor.wysiwyg.afterRenderTimeoutId = 0;
             return;
         }
         const text = getMarkdown(vditor);
@@ -37,5 +38,6 @@ export const afterRenderEvent = (vditor: IVditor, options = {
         if (options.enableAddUndoStack) {
             vditor.undo.addToUndoStack(vditor);
         }
+        vditor.wysiwyg.afterRenderTimeoutId = 0;
     }, vditor.options.undoDelay);
 };


### PR DESCRIPTION
<!--

* PR 请提交到 dev 开发分支上

-->
Undo could miss the latest edit if it had not been added to the undo stack yet.
This change flushes pending undo state before undo/redo runs, while keeping theexisting undo delay as-is.